### PR TITLE
adds support for installing ansible and running a test playbook

### DIFF
--- a/parallels-debian11.pkr.hcl
+++ b/parallels-debian11.pkr.hcl
@@ -197,30 +197,34 @@ build {
   sources = ["source.parallels-iso.debian11"]
 
   provisioner "file" {
-    source = "scripts/${var.repo}_config.sh"
-    destination = "/tmp/${var.repo}_config.sh"
-  }
-
-  provisioner "file" {
     source = "scripts/packer-sudo"
     destination = "/tmp/packer-sudo"
   }
 
   provisioner "shell" {
     inline = [
-      "echo 'packer' | TERM=xterm sudo -S mkdir -p /tmp/parallels",
-      "echo 'packer' | TERM=xterm sudo -S mount -o loop /home/packer/prl-tools-lin-arm.iso /tmp/parallels",
-      "echo 'packer' | TERM=xterm sudo -S /tmp/parallels/install --install-unattended-with-deps"
+      "echo 'packer' | TERM=xterm sudo -S mv /tmp/packer-sudo /etc/sudoers.d/packer",
+      "echo 'packer' | TERM=xterm sudo -S chown root.root /etc/sudoers.d/packer",
     ]
   }
 
+  #provisioner "shell" {
+    #inline = [
+      #"TERM=xterm sudo -S mkdir -p /tmp/parallels",
+      #"TERM=xterm sudo -S mount -o loop /home/packer/prl-tools-lin-arm.iso /tmp/parallels",
+      #"TERM=xterm sudo -S /tmp/parallels/install --install-unattended-with-deps"
+    #]
+  #}
+
   provisioner "shell" {
-    inline = [
-      "echo 'packer' | TERM=xterm sudo -S mv /tmp/packer-sudo /etc/sudoers.d/packer",
-      "echo 'packer' | TERM=xterm sudo -S chown root.root /etc/sudoers.d/packer",
-      "/tmp/${var.repo}_config.sh ${var.branch}"
-    ]
+    script = "scripts/install-ansible.sh"  
   }
+
+  provisioner "ansible-local" {
+    playbook_file   = "playbooks/test_playbook.yaml"
+    extra_arguments = ["--extra-vars", "\"branch=${var.branch}\""]
+  }
+
 }
 
 

--- a/playbooks/test_playbook.yaml
+++ b/playbooks/test_playbook.yaml
@@ -1,0 +1,9 @@
+---
+- name: test playbook
+  hosts: 127.0.0.1
+  connection: local
+
+  tasks:
+    - command: echo {{ branch }}
+    - debug: msg="{{ branch }}"
+

--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -1,0 +1,2 @@
+sudo apt install -y python3.9 python3-pip
+sudo python3.9 -m pip install ansible


### PR DESCRIPTION
This comments out the install of parallels tools, just for speed at this early stage. It will eventually be re-enabled. 