### PR TITLE
Direct node install

### DIFF
--- a/playbooks/clone_repos.yaml
+++ b/playbooks/clone_repos.yaml
@@ -8,6 +8,7 @@
     repos:
       - kiosk-browser
       - vxsuite
+      - vxsuite-build-system
       - vxsuite-complete-system
 
   tasks:

--- a/playbooks/setup-node.yaml
+++ b/playbooks/setup-node.yaml
@@ -14,22 +14,31 @@
 
     - name: Determine system architecture
       set_fact:
-        architecture: "{{ 'arm64' if (ansible_architecture == 'aarch64' || ansible_architecture == 'arm64') else 'x64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
+        architecture: "{{ 'arm64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
 
     - name: Install/Upgrade Node on supported architectures
       block:
 
         - name: Set Node release URL
           set_fact:
-            release_url: "https://nodejs.org/dist/v{{ node_version }}}/node-v{{ node_version }}-linux-{{ architecture }}.tar.gz"
+            release_url: "https://nodejs.org/dist/v{{ node_version }}/node-v{{ node_version }}-linux-{{ architecture }}.tar.gz"
 
         - name: Download and extract Node
-        ansible.builtin.unarchive:
-          src: "{{ release_url }}"
-          dest: /usr/local
-          remote_src: yes
-          extra_opts:
-            - --strip-components=1
+          ansible.builtin.unarchive:
+            src: "{{ release_url }}"
+            dest: /usr/local
+            remote_src: yes
+            extra_opts:
+              - --strip-components=1
+
+        - name: See if corepack is present
+          command: "which corepack"
+          register: corepack_installed
+          ignore_errors: yes
+
+        - name: Disable corepack if installed
+          command: corepack disable
+          when: corepack_installed.rc == 0
 
         - name: Install package managers
           community.general.npm:

--- a/playbooks/setup-node.yaml
+++ b/playbooks/setup-node.yaml
@@ -1,42 +1,42 @@
 ---
-- name: Install Node and other dependencies
+- name: Install/Upgrade Node and other dependencies
   hosts: 127.0.0.1
   connection: local
   become: true
 
   vars:
-    node_version: "16.19.*"
-    node_repo_version: "16.x"
+    node_version: "16.19.1"
     npm_packages:
-      - yarn
+      - yarn@1.22.15
       - pnpm@7.24.3
 
   tasks:
 
-    - name: "Add nodejs apt key"
-      ansible.builtin.apt_key:
-        url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-        state: present
+    - name: Determine system architecture
+      set_fact:
+        architecture: "{{ 'arm64' if (ansible_architecture == 'aarch64' || ansible_architecture == 'arm64') else 'x64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
 
-    - name: "Add nodejs {{ node_version }} apt repo"
-      ansible.builtin.apt_repository:
-        repo: deb https://deb.nodesource.com/node_{{ node_repo_version }} bullseye main
-        update_cache: yes
+    - name: Install/Upgrade Node on supported architectures
+      block:
 
-    - name: "Add nodejs {{ node_version }} src apt repo"
-      ansible.builtin.apt_repository:
-        repo: deb-src https://deb.nodesource.com/node_{{ node_repo_version }} bullseye main
-        update_cache: yes
+        - name: Set Node release URL
+          set_fact:
+            release_url: "https://nodejs.org/dist/v{{ node_version }}}/node-v{{ node_version }}-linux-{{ architecture }}.tar.gz"
 
-    - name: "Install Node {{ node_version }}"
-      ansible.builtin.apt:
-        update_cache: yes
-        name: "nodejs={{ node_version }}"
-        state: present
+        - name: Download and extract Node
+        ansible.builtin.unarchive:
+          src: "{{ release_url }}"
+          dest: /usr/local
+          remote_src: yes
+          extra_opts:
+            - --strip-components=1
 
-    - name: "Install base npm packages"
-      community.general.npm:
-        global: yes
-        name: "{{ item }}"
-      loop: "{{ npm_packages }}"
+        - name: Install package managers
+          community.general.npm:
+            global: yes
+            name: "{{ item }}"
+          loop: "{{ npm_packages }}"
+
+      when: architecture != 'unsupported'
+
 

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEBIAN_FRONTEND=noninteractive sudo apt update
-DEBIAN_FRONTEND=noninteractive sudo apt install -y sudo git make build-essential curl wget ssh tar gzip ca-certificates libx11-dev libpng-dev libjpeg-dev xvfb zip
+DEBIAN_FRONTEND=noninteractive apt update
+DEBIAN_FRONTEND=noninteractive apt install -y sudo git make build-essential curl wget ssh tar gzip ca-certificates libx11-dev libpng-dev libjpeg-dev xvfb zip
 
 exit 0


### PR DESCRIPTION
No longer relies on debian repositories for (potentially) older versions of node.

Ensures corepack is not active when configuring package managers. 