### PR TITLE
Install and configure rust in various build environments

### DIFF
--- a/docker-debian11-nodejs-browsers.pkr.hcl
+++ b/docker-debian11-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "2.0.1"
+  default = "2.0.2"
 }
 
 source "docker" "debian11-browsers" {
@@ -33,6 +33,7 @@ build {
     playbook_files  = [
       "playbooks/install-vxsuite-packages.yaml",
       "playbooks/install-node.yaml",
+      "playbooks/install-rust.yaml",
       "playbooks/install-selenium.yaml"
     ]
   }

--- a/docker-debian11-nodejs-browsers.pkr.hcl
+++ b/docker-debian11-nodejs-browsers.pkr.hcl
@@ -30,6 +30,7 @@ build {
   }
 
   provisioner "ansible-local" {
+    playbook_dir = "./playbooks"
     playbook_files  = [
       "playbooks/install-vxsuite-packages.yaml",
       "playbooks/install-node.yaml",

--- a/docker-debian11-nodejs.pkr.hcl
+++ b/docker-debian11-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "2.0.1"
+  default = "2.0.2"
 }
 
 source "docker" "debian11" {
@@ -32,7 +32,8 @@ build {
   provisioner "ansible-local" {
     playbook_files  = [
       "playbooks/install-vxsuite-packages.yaml",
-      "playbooks/install-node.yaml"
+      "playbooks/install-node.yaml",
+      "playbooks/install-rust.yaml"
     ]
   }
 

--- a/docker-debian11-nodejs.pkr.hcl
+++ b/docker-debian11-nodejs.pkr.hcl
@@ -30,6 +30,7 @@ build {
   }
 
   provisioner "ansible-local" {
+    playbook_dir = "./playbooks"
     playbook_files  = [
       "playbooks/install-vxsuite-packages.yaml",
       "playbooks/install-node.yaml",

--- a/parallels-debian11.pkr.hcl
+++ b/parallels-debian11.pkr.hcl
@@ -234,6 +234,7 @@ build {
   }
 
   provisioner "ansible-local" {
+    playbook_dir = "./playbooks"
     playbook_files  = [
       "playbooks/create_local_user.yaml",
       "playbooks/clone_repos.yaml",

--- a/parallels-debian11.pkr.hcl
+++ b/parallels-debian11.pkr.hcl
@@ -238,7 +238,8 @@ build {
       "playbooks/create_local_user.yaml",
       "playbooks/clone_repos.yaml",
       "playbooks/install-vxsuite-packages.yaml",
-      "playbooks/install-node.yaml"
+      "playbooks/install-node.yaml",
+      "playbooks/install-rust.yaml"
     ]
     extra_arguments = ["--extra-vars", "local_user=${var.local_user}"]
   }

--- a/playbooks/configure-rust-env.yaml
+++ b/playbooks/configure-rust-env.yaml
@@ -5,7 +5,7 @@
   become: true
 
   vars:
-    user_to_configure: "{{ ansible_env.SUDO_USER }}"
+    user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
     rustup_home: "/usr/local/rustup"
     cargo_home: "/usr/local/cargo"
 

--- a/playbooks/configure-rust-env.yaml
+++ b/playbooks/configure-rust-env.yaml
@@ -2,9 +2,10 @@
 - name: Configure the rust environment for a user
   hosts: 127.0.0.1
   connection: local
+  become: true
 
   vars:
-    user_to_configure: "{{ ansible_user_id }}"
+    user_to_configure: "{{ ansible_env.SUDO_USER }}"
     rustup_home: "/usr/local/rustup"
     cargo_home: "/usr/local/cargo"
 

--- a/playbooks/configure-rust-env.yaml
+++ b/playbooks/configure-rust-env.yaml
@@ -1,0 +1,31 @@
+---     
+- name: Configure the rust environment for a user
+  hosts: 127.0.0.1
+  connection: local
+
+  vars:
+    user_to_configure: "{{ ansible_user_id }}"
+    rustup_home: "/usr/local/rustup"
+    cargo_home: "/usr/local/cargo"
+
+  tasks:
+
+    - name: Override user if local_user is defined
+      set_fact:
+        user_to_configure: "{{ local_user }}"
+      when: (local_user is defined) and (local_user|length > 0)
+
+    - name: Set Rustup path for {{ user_to_configure }}
+      ansible.builtin.lineinfile:
+        path: "~{{ user_to_configure }}/.bashrc"
+        line: "export RUSTUP_HOME={{ rustup_home }}"
+
+    - name: Set Rust Cargo path for {{ user_to_configure }}
+      ansible.builtin.lineinfile:
+        path: "~{{ user_to_configure }}/.bashrc"
+        line: "export CARGO_HOME={{ cargo_home }}"
+
+    - name: Ensure we source the global cargo ENV for {{ user_to_configure }}
+      ansible.builtin.lineinfile:
+        path: "~{{ user_to_configure }}/.bashrc"
+        line: ". {{ cargo_home }}/env"

--- a/playbooks/configure-rust-env.yaml
+++ b/playbooks/configure-rust-env.yaml
@@ -7,7 +7,7 @@
   vars:
     user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
     rustup_home: "/usr/local/rustup"
-    cargo_home: "/usr/local/cargo"
+    cargo_env: "/usr/local/cargo"
 
   tasks:
 
@@ -21,12 +21,20 @@
         path: "~{{ user_to_configure }}/.bashrc"
         line: "export RUSTUP_HOME={{ rustup_home }}"
 
+    - name: Create local cargo registry for {{ user_to_configure }}
+      ansible.builtin.file:
+        path: "~{{ user_to_configure }}/.cargo"
+        owner: "{{ user_to_configure }}"
+        group: "{{ user_to_configure }}"
+        state: directory
+        mode: '0755'
+
     - name: Set Rust Cargo path for {{ user_to_configure }}
       ansible.builtin.lineinfile:
         path: "~{{ user_to_configure }}/.bashrc"
-        line: "export CARGO_HOME={{ cargo_home }}"
+        line: "export CARGO_HOME=~{{ user_to_configure }}/.cargo"
 
     - name: Ensure we source the global cargo ENV for {{ user_to_configure }}
       ansible.builtin.lineinfile:
         path: "~{{ user_to_configure }}/.bashrc"
-        line: ". {{ cargo_home }}/env"
+        line: ". {{ cargo_env }}/env"

--- a/playbooks/create_local_user.yaml
+++ b/playbooks/create_local_user.yaml
@@ -4,9 +4,6 @@
   connection: local
   become: true
 
-  vars:
-    cargo_home: "/usr/local/cargo"
-
   tasks:
     - name: Create user
       ansible.builtin.user:
@@ -32,20 +29,5 @@
         line: "export PATH=$PATH:/usr/sbin"
       when: (local_user is defined) and (local_user|length > 0)
 
-    - name: Set Rustup path
-      ansible.builtin.lineinfile:
-        path: "~{{ local_user }}/.bashrc"
-        line: "export RUSTUP_HOME=/usr/local/rustup"
-      when: (local_user is defined) and (local_user|length > 0)
-
-    - name: Set Rust Cargo path
-      ansible.builtin.lineinfile:
-        path: "~{{ local_user }}/.bashrc"
-        line: "export CARGO_HOME=/usr/local/cargo"
-      when: (local_user is defined) and (local_user|length > 0)
-
-    - name: Ensure we source the global cargo ENV
-      ansible.builtin.lineinfile:
-        path: "~{{ local_user }}/.bashrc"
-        line: ". {{ cargo_home }}/env"
-      when: (local_user is defined) and (local_user|length > 0)
+- import_playbook: configure-rust-env.yaml
+  when: (local_user is defined) and (local_user|length > 0)

--- a/playbooks/create_local_user.yaml
+++ b/playbooks/create_local_user.yaml
@@ -4,6 +4,9 @@
   connection: local
   become: true
 
+  vars:
+    cargo_home: "/usr/local/cargo"
+
   tasks:
     - name: Create user
       ansible.builtin.user:
@@ -25,6 +28,24 @@
 
     - name: Ensure /usr/sbin is part of PATH
       ansible.builtin.lineinfile:
-        path: "/home/{{ local_user }}/.bashrc"
-        line: "PATH=$PATH:/usr/sbin"
+        path: "~{{ local_user }}/.bashrc"
+        line: "export PATH=$PATH:/usr/sbin"
+      when: (local_user is defined) and (local_user|length > 0)
+
+    - name: Set Rustup path
+      ansible.builtin.lineinfile:
+        path: "~{{ local_user }}/.bashrc"
+        line: "export RUSTUP_HOME=/usr/local/rustup"
+      when: (local_user is defined) and (local_user|length > 0)
+
+    - name: Set Rust Cargo path
+      ansible.builtin.lineinfile:
+        path: "~{{ local_user }}/.bashrc"
+        line: "export CARGO_HOME=/usr/local/cargo"
+      when: (local_user is defined) and (local_user|length > 0)
+
+    - name: Ensure we source the global cargo ENV
+      ansible.builtin.lineinfile:
+        path: "~{{ local_user }}/.bashrc"
+        line: ". {{ cargo_home }}/env"
       when: (local_user is defined) and (local_user|length > 0)

--- a/playbooks/install-rust.yaml
+++ b/playbooks/install-rust.yaml
@@ -2,7 +2,6 @@
 - name: Install Rust
   hosts: 127.0.0.1
   connection: local
-  become: true
 
   vars:
     rust_version: '1.68.0'
@@ -18,7 +17,10 @@
         url: "{{ rustup_install_url }}"
         dest: "{{ rustup_install_cmd }}"
 
+    #-- Runs as root
     - name: Install Rust {{ rust_version }}
       ansible.builtin.shell:
         cmd: "cat {{ rustup_install_cmd }} | RUSTUP_HOME={{ rustup_home }} CARGO_HOME={{ cargo_home }} sh -s -- --default-toolchain {{ rust_version }} -y"
+      become: true
 
+- import_playbook: configure-rust-env.yaml

--- a/playbooks/install-rust.yaml
+++ b/playbooks/install-rust.yaml
@@ -1,0 +1,24 @@
+---
+- name: Install Rust
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  vars:
+    rust_version: '1.68.0'
+    rustup_home: '/usr/local/rustup'
+    cargo_home: '/usr/local/cargo'
+    rustup_install_url: 'https://sh.rustup.rs'
+    rustup_install_cmd: '/tmp/rustup.sh'
+
+  tasks:
+
+    - name: Download rustup
+      ansible.builtin.get_url:
+        url: "{{ rustup_install_url }}"
+        dest: "{{ rustup_install_cmd }}"
+
+    - name: Install Rust {{ rust_version }}
+      ansible.builtin.shell:
+        cmd: "cat {{ rustup_install_cmd }} | RUSTUP_HOME={{ rustup_home }} CARGO_HOME={{ cargo_home }} sh -s -- --default-toolchain {{ rust_version }} -y"
+


### PR DESCRIPTION
This PR installs a pinned version of Rust globally, and configures standard user environments per build types. It also supports running the installation playbook in an existing environment to properly install and configure Rust. 

This will close https://github.com/votingworks/vxsuite-build-system/issues/18