### PR TITLE
Upgrade pnpm

### DIFF
--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -8,7 +8,7 @@
     node_version: "16.19.1"
     npm_packages:
       - yarn@1.22.15
-      - pnpm@7.24.3
+      - pnpm@8.1.0
 
   tasks:
 


### PR DESCRIPTION
I was encountering the following error when running `make build` in `vxsuite-complete-system` while creating images:

```
Scope: all 29 workspace projects
 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "settings.autoInstallPeers" configuration doesn't match the value found in the lockfile
```

@eventualbuddha noted that we should be using pnpm version 8.1.0. Upgrading pnpm to 8.1.0 did in fact solve the issue!