### PR TITLE
Online/offline build support for apt packages

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+base_dir = .
+roles_path = ./roles

--- a/playbooks/trusted_build/packages.yaml
+++ b/playbooks/trusted_build/packages.yaml
@@ -96,6 +96,6 @@
       set_fact:
         all_packages: "{{ all_packages | unique | select | list }}"
 
-    - name: Download the packages without installing
+    - name: Import the apt role which supports online and offline builds
       ansible.builtin.import_role:
         name: apt

--- a/playbooks/trusted_build/packages.yaml
+++ b/playbooks/trusted_build/packages.yaml
@@ -1,0 +1,101 @@
+---
+
+- name: Install system level dependencies used by various apps and services
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  vars:
+    base_packages:
+      - build-essential
+      - curl
+      - make
+      - gzip
+      - zip
+      - tar
+      - libsane 
+      - libpng-dev 
+      - libjpeg-dev 
+      - libx11-dev 
+      - libpixman-1-dev 
+      - libcairo2-dev 
+      - libpango1.0-dev 
+      - libgif-dev 
+
+    libs_auth_packages:
+      - default-jdk
+      - wget
+
+    svc_converter_ms_sems_packages:
+      - python3.9 
+      - python3.9-dev 
+      - python3-distutils 
+      - python3-pip
+
+    svc_smartcards_packages:
+      - python3.9 
+      - python3.9-dev 
+      - python3.9-distutils 
+      - python3-pip 
+      - libusb-1.0-0-dev 
+      - libpcsclite-dev 
+      - pcscd 
+      - pcsc-tools 
+      - swig 
+
+    app_admin_packages:
+      - fdisk 
+      - dosfstools 
+      - exfat-utils
+      - libpcsclite1
+      - libpcsclite-dev
+
+    app_central_scan_packages:
+      - libsane 
+      - libpng-dev 
+      - libjpeg-dev 
+      - libx11-dev 
+      - libpixman-1-dev 
+      - libcairo2-dev 
+      - libpango1.0-dev 
+      - libgif-dev
+      - libpcsclite1
+      - libpcsclite-dev
+
+    app_mark_packages:
+      - libpcsclite1
+      - libpcsclite-dev
+
+    app_scan_packages:
+      - libsane 
+      - libpng-dev 
+      - libjpeg-dev 
+      - libx11-dev 
+      - libpixman-1-dev 
+      - libcairo2-dev 
+      - libpango1.0-dev 
+      - libgif-dev
+      - libpcsclite1
+      - libpcsclite-dev
+
+  tasks:
+    - name: Create a list of all the packages we need
+      set_fact:
+        all_packages: "{{ all_packages | default([]) + [ item ] }}"
+      with_items:
+        - "{{ base_packages | default([]) }}"
+        - "{{ libs_auth_packages | default([]) }}"
+        - "{{ svc_converter_ms_sems_packages | default([]) }}"
+        - "{{ svc_smartcards_packages | default([]) }}"
+        - "{{ app_admin_packages | default([]) }}"
+        - "{{ app_central_scan_packages | default([]) }}"
+        - "{{ app_mark_packages | default([]) }}"
+        - "{{ app_scan_packages | default([]) }}"
+
+    - name: De-dupe the list for efficiency
+      set_fact:
+        all_packages: "{{ all_packages | unique | select | list }}"
+
+    - name: Download the packages without installing
+      ansible.builtin.import_role:
+        name: apt

--- a/roles/apt/tasks/download_only.yaml
+++ b/roles/apt/tasks/download_only.yaml
@@ -1,0 +1,13 @@
+---
+
+#-- Note: We may want to remove this so packages from the preseed 
+#--       Debian install are available. Need more info from SLI
+- name: Clean out any existing packages
+  ansible.builtin.apt:
+    clean: yes
+
+- name: Download the packages and dependencies
+  ansible.builtin.command:
+    cmd: "apt-get install --reinstall --download-only {{ item }}"
+  with_items:
+    - "{{ all_packages }}"

--- a/roles/apt/tasks/main.yaml
+++ b/roles/apt/tasks/main.yaml
@@ -1,0 +1,15 @@
+---
+
+- import_tasks: download_only.yaml
+  tags:
+    - online
+
+- name: Install the packages
+  ansible.builtin.apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ all_packages }}"
+  tags:
+    - offline
+


### PR DESCRIPTION
This is the first step toward an online/offline build process in support of Trusted Build certification.

By default, running the `playbooks/trusted_build/packages.yaml` playbook will download and install packages. This assumes an online connection so that day-to-day dev work is not impacted while still using the underlying online/offline functionality.

For the online phase, in which we are not allowed to install the packages, you can skip the offline phase by adding `skip-tags offline` to the playbook run.

For the offline phase, in which we have no network connection and can only install from locally available files, you can skip the package downloads by adding `skip-tags online` to the playbook run.