### PR TITLE
Trusted build for votingworks repos

### DIFF
--- a/inventories/m16-rc3/group_vars/all/main.yaml
+++ b/inventories/m16-rc3/group_vars/all/main.yaml
@@ -1,0 +1,3 @@
+repos:
+  vxsuite-complete-system:
+    version: m16-rc3

--- a/inventories/m16-rc3/hosts
+++ b/inventories/m16-rc3/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -5,33 +5,39 @@
   become: yes
 
   vars:
-    downloads_directory: "/tmp"
+    downloads_directory: "/tmp/code"
     user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
-    repos:
-      kiosk-browser:
-      vxsuite:
-      vxsuite-complete-system:
-        version: "m16-rc3"
+    code_directory: "~{{ user_to_configure }}/code"
 
   tasks:
 
+    #-- Default to main branch in all repos unless defined elsewhere
+    - name: Configure the repos dictionary if not already defined
+      set_fact:
+        repos:
+          kiosk-browser:
+          vxsuite:
+          vxsuite-complete-system:
+      when: repos is not defined
+      
     - name: Online tasks for git repos
       block:
 
-      - name: Make sure the {{ downloads_directory }}/code directory does not exist from a previous build
+      - name: Make sure the {{ downloads_directory }} directory does not exist from a previous build
         ansible.builtin.file:
-          path: "{{ downloads_directory }}/code"
+          path: "{{ downloads_directory }}"
           state: absent
+        when: (downloads_directory is defined) and (downloads_directory|length > 0)
 
       - name: Create the code subdir
         ansible.builtin.file:
-          path: "{{ downloads_directory }}/code"
+          path: "{{ downloads_directory }}"
           state: directory
           mode: '0755'
   
       - name: Create the repo subdirs in the code dir
         ansible.builtin.file:
-          path: "{{ downloads_directory }}/code/{{ item.key }}"
+          path: "{{ downloads_directory }}/{{ item.key }}"
           state: directory
           mode: '0755'
         with_dict: "{{ repos }}"
@@ -42,7 +48,7 @@
       - name: Clone the votingworks repos
         ansible.builtin.git:
           repo: "https://github.com/votingworks/{{ item.key }}.git"
-          dest: "{{ downloads_directory }}/code/{{ item.key }}"
+          dest: "{{ downloads_directory }}/{{ item.key }}"
           version: "{{ item.value.version | default('main') }}"
         with_dict: "{{ repos }}"
 
@@ -52,19 +58,19 @@
     #-- TODO: Should this just be part of an initial script copy instead?
     - name: Offline tasks for git repos
       block:
-        - name: Check that the expected {{ downloads_directory }}/code directory exists
+        - name: Check that the expected {{ downloads_directory }} directory exists
           ansible.builtin.stat:
-            path: "{{ downloads_directory }}/code"
+            path: "{{ downloads_directory }}"
           register: code_dir_info
 
-        - name: Error if {{ downloads_directory }}/code does not exist
+        - name: Error if {{ downloads_directory }} does not exist
           ansible.builtin.fail:
-            msg: "Error: The expected {{ downloads_directory }}/code directory does not exist."
+            msg: "Error: The expected {{ downloads_directory }} directory does not exist."
           when: not code_dir_info.stat.exists or not code_dir_info.stat.isdir
 
-        - name: Create the ~{{ user_to_configure }}/code2 directory
+        - name: Create the {{ code_directory }} directory
           ansible.builtin.file:
-            path: "~{{ user_to_configure }}/code2"
+            path: "{{ code_directory }}"
             owner: "{{ user_to_configure }}"
             group: "{{ user_to_configure }}"
             mode: '0755'
@@ -72,7 +78,7 @@
 
         - name: Check for any existing repos
           ansible.builtin.stat:
-            path: "~{{ user_to_configure }}/code2/{{ item }}"
+            path: "{{ code_directory }}/{{ item }}"
           with_items: "{{ repos | list }}"
           register: repos_info
 
@@ -82,10 +88,10 @@
           when: item.stat.exists
           with_items: "{{ repos_info.results }}"
 
-        - name: Copy {{ downloads_directory }}/code to ~{{ user_to_configure }}/code2 directory
+        - name: Copy {{ downloads_directory }} to {{ code_directory }}
           ansible.builtin.copy:
-            src: "{{ downloads_directory }}/code/"
-            dest: "~{{ user_to_configure }}/code2/"
+            src: "{{ downloads_directory }}/"
+            dest: "{{ code_directory }}"
             remote_src: yes
             owner: "{{ user_to_configure }}"
             group: "{{ user_to_configure }}"

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -6,40 +6,78 @@
 
   vars:
     downloads_directory: "/tmp"
+    user_to_configure: "amcmanus"
     repos:
-      - kiosk-browser
-      - vxsuite
-      - vxsuite-build-system
-      - vxsuite-complete-system
+      kiosk-browser:
+      vxsuite:
+      vxsuite-build-system:
+      vxsuite-complete-system:
+        version: "m16-rc3"
 
   tasks:
 
-    - name: Create the code subdir
-      ansible.builtin.file:
-        path: "{{ downloads_directory }}/code"
-        state: directory
-        mode: '0755'
-      tags:
-        - online
+    - name: Online tasks for git repos
+      block:
 
-    - name: Create the repo subdirs in the code dir
-      ansible.builtin.file:
-        path: "{{ downloads_directory }}/code/{{ item }}"
-        state: directory
-        mode: '0755'
-      loop: "{{ repos }}"
-      tags:
-        - online
+      - name: Make sure the {{ downloads_directory }}/code directory does not exist from a previous build
+        ansible.builtin.file:
+          path: "{{ downloads_directory }}/code"
+          state: absent
+
+      - name: Create the code subdir
+        ansible.builtin.file:
+          path: "{{ downloads_directory }}/code"
+          state: directory
+          mode: '0755'
   
-    #-- Need to handle submodules more dynamically
-    #-- The default behavior below automatically pulls them from main
-    #-- Probably use an inventory to define this but initial tests
-    #-- had strange permissions issues
-    - name: Clone the votingworks repos
-      ansible.builtin.git:
-        repo: "https://github.com/votingworks/{{ item }}.git"
-        dest: "{{ downloads_directory }}/code/{{ item }}"
-      loop: "{{ repos }}"
+      - name: Create the repo subdirs in the code dir
+        ansible.builtin.file:
+          path: "{{ downloads_directory }}/code/{{ item.key }}"
+          state: directory
+          mode: '0755'
+        with_dict: "{{ repos }}"
+    
+      #-- Note: this defaults to main AND automatically updates submodules
+      #-- You need to specify the branch/tag/commit in the repos dictionary
+      #-- if you want anything other than main
+      - name: Clone the votingworks repos
+        ansible.builtin.git:
+          repo: "https://github.com/votingworks/{{ item.key }}.git"
+          dest: "{{ downloads_directory }}/code/{{ item.key }}"
+          version: "{{ item.value.version | default('main') }}"
+        with_dict: "{{ repos }}"
+
       tags:
         - online
 
+    - name: Offline tasks for git repos
+      block:
+        - name: Check that the expected {{ downloads_directory }}/code directory exists
+          ansible.builtin.stat:
+            path: "{{ downloads_directory }}/code"
+          register: code_dir_info
+
+        - block:
+            - name: Error if {{ downloads_directory }}/code does not exist
+              ansible.builtin.debug:
+                msg: "Error: The expected {{ downloads_directory }}/code directory does not exist."
+
+            - meta: end_play
+          when: not code_dir_info.stat.exists or not code_dir_info.stat.isdir
+
+        - name: Create the ~{{ user_to_configure }}/code2 directory
+          ansible.builtin.file:
+            path: "~{{ user_to_configure }}/code2"
+            owner: "{{ user_to_configure }}"
+            group: "{{ user_to_configure }}"
+            mode: '0755'
+            state: directory
+
+        - name: Copy {{ downloads_directory }}/code to ~{{ user_to_configure }}/code2 directory
+          ansible.builtin.copy:
+            src: "{{ downloads_directory }}/code/"
+            dest: "~{{ user_to_configure }}/code2/"
+            remote_src: yes
+
+      tags:
+        - offline

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -6,11 +6,10 @@
 
   vars:
     downloads_directory: "/tmp"
-    user_to_configure: "amcmanus"
+    user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
     repos:
       kiosk-browser:
       vxsuite:
-      vxsuite-build-system:
       vxsuite-complete-system:
         version: "m16-rc3"
 
@@ -50,6 +49,7 @@
       tags:
         - online
 
+    #-- TODO: Should this just be part of an initial script copy instead?
     - name: Offline tasks for git repos
       block:
         - name: Check that the expected {{ downloads_directory }}/code directory exists
@@ -73,11 +73,25 @@
             mode: '0755'
             state: directory
 
+        - name: Check for any existing repos
+          ansible.builtin.stat:
+            path: "~{{ user_to_configure }}/code2/{{ item }}"
+          with_items: "{{ repos | list }}"
+          register: repos_info
+
+        - name: If any repos already exist, exit the playbook so we don't overwrite pre-existsing work in localdev
+          ansible.builtin.fail:
+            msg: "{{ item.item }} exists already."
+          when: item.stat.exists
+          with_items: "{{ repos_info.results }}"
+
         - name: Copy {{ downloads_directory }}/code to ~{{ user_to_configure }}/code2 directory
           ansible.builtin.copy:
             src: "{{ downloads_directory }}/code/"
             dest: "~{{ user_to_configure }}/code2/"
             remote_src: yes
+            owner: "{{ user_to_configure }}"
+            group: "{{ user_to_configure }}"
 
       tags:
         - offline

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -1,0 +1,45 @@
+---
+- name: Clone votingworks repos
+  hosts: 127.0.0.1
+  connection: local
+  become: yes
+
+  vars:
+    downloads_directory: "/tmp"
+    repos:
+      - kiosk-browser
+      - vxsuite
+      - vxsuite-build-system
+      - vxsuite-complete-system
+
+  tasks:
+
+    - name: Create the code subdir
+      ansible.builtin.file:
+        path: "{{ downloads_directory }}/code"
+        state: directory
+        mode: '0755'
+      tags:
+        - online
+
+    - name: Create the repo subdirs in the code dir
+      ansible.builtin.file:
+        path: "{{ downloads_directory }}/code/{{ item }}"
+        state: directory
+        mode: '0755'
+      loop: "{{ repos }}"
+      tags:
+        - online
+  
+    #-- Need to handle submodules more dynamically
+    #-- The default behavior below automatically pulls them from main
+    #-- Probably use an inventory to define this but initial tests
+    #-- had strange permissions issues
+    - name: Clone the votingworks repos
+      ansible.builtin.git:
+        repo: "https://github.com/votingworks/{{ item }}.git"
+        dest: "{{ downloads_directory }}/code/{{ item }}"
+      loop: "{{ repos }}"
+      tags:
+        - online
+

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -16,8 +16,11 @@
       set_fact:
         repos:
           kiosk-browser:
+            version: main
           vxsuite:
+            version: main
           vxsuite-complete-system:
+            version: main
       when: repos is not defined
       
     - name: Online tasks for git repos

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -57,12 +57,9 @@
             path: "{{ downloads_directory }}/code"
           register: code_dir_info
 
-        - block:
-            - name: Error if {{ downloads_directory }}/code does not exist
-              ansible.builtin.debug:
-                msg: "Error: The expected {{ downloads_directory }}/code directory does not exist."
-
-            - meta: end_play
+        - name: Error if {{ downloads_directory }}/code does not exist
+          ansible.builtin.fail:
+            msg: "Error: The expected {{ downloads_directory }}/code directory does not exist."
           when: not code_dir_info.stat.exists or not code_dir_info.stat.isdir
 
         - name: Create the ~{{ user_to_configure }}/code2 directory


### PR DESCRIPTION
Only real thing to note here is the failure case when a repo is already present on the system. I don't want to risk overwriting existing work in a localdev environment, so it's a hard fail for now. In the future, it might be worth looking at other options, but this covers building a new VM without risking localdev.

This also provides an example of using default variables (`repos`) that can also be defined in a separate inventory. This enables overriding configs for specific build releases, and is a pattern that will be used more and more for the build system.