### PR TITLE
workaround for apt dependency issue

### DIFF
--- a/roles/apt/tasks/download_only.yaml
+++ b/roles/apt/tasks/download_only.yaml
@@ -6,8 +6,17 @@
   ansible.builtin.apt:
     clean: yes
 
+- name: Update the cache after cleaning
+  ansible.builtin.apt:
+    update_cache: yes
+
+#-- This is expected to run on a clean system
+#-- Dependencies are then pulled in correctly
+#-- If on an existing system, this can break if 
+#-- a dependency is already installed
+#-- TODO: Make it work on pre-existing systems???
 - name: Download the packages and dependencies
   ansible.builtin.command:
-    cmd: "apt-get install --reinstall --download-only {{ item }}"
+    cmd: "apt-get install --reinstall --download-only -y {{ item }}"
   with_items:
     - "{{ all_packages }}"


### PR DESCRIPTION
As noted, this solves package dependencies as long as it's run on a clean system (the trusted build expectation). At this time, no plans to support running from a previously configured system since that breaks the trusted build paradigm and could introduce incorrect package versions based on unrelated installs.