### PR TITLE
Minimal scripts to assist in online/offline VM pre-requisites 

### DIFF
--- a/playbooks/trusted_build/all.yaml
+++ b/playbooks/trusted_build/all.yaml
@@ -1,0 +1,9 @@
+---
+- name: All the trusted build steps
+  hosts: 127.0.0.1
+  connection: local
+  become: yes
+
+- import_playbook: packages.yaml
+- import_playbook: node.yaml
+- import_playbook: rust.yaml

--- a/playbooks/trusted_build/node.yaml
+++ b/playbooks/trusted_build/node.yaml
@@ -6,13 +6,16 @@
 
   #-- TODO: move downloads_directory to defaults/inventory
   vars:
-    downloads_directory: "/tmp"
+    downloads_directory: "/tmp/downloads"
     node_version: "16.19.1"
     npm_packages:
       - yarn@1.22.15
       - pnpm@8.1.0
 
   tasks:
+
+    - import_tasks: shared_tasks/user_to_configure.yaml
+    - import_tasks: shared_tasks/well_known_paths.yaml
 
     - name: Determine system architecture
       set_fact:

--- a/playbooks/trusted_build/rust.yaml
+++ b/playbooks/trusted_build/rust.yaml
@@ -5,12 +5,13 @@
   become: true
 
   vars:
-    downloads_directory: "/tmp"
+    downloads_directory: "/tmp/downloads"
     rust_version: '1.68.0'
 
   tasks:
 
     - import_tasks: shared_tasks/user_to_configure.yaml
+    - import_tasks: shared_tasks/well_known_paths.yaml
 
     - name: Determine system architecture for appropriate Rust install
       set_fact: 
@@ -31,8 +32,6 @@
       ansible.builtin.get_url:
         url: "{{ rust_tarball_url }}"
         dest: "{{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
-      become: true
-      become_user: "{{ user_to_configure }}"
       tags:
         - online
 

--- a/playbooks/trusted_build/shared_tasks/well_known_paths.yaml
+++ b/playbooks/trusted_build/shared_tasks/well_known_paths.yaml
@@ -16,3 +16,8 @@
         system_path: "~{{ user_to_configure }}/code/vxsuite-build-system"
         usb_path: "vxsuite-build-system"
     
+- name: Be sure to create /tmp/downloads
+  ansible.builtin.file:
+    path: "/tmp/downloads"
+    state: directory
+    mode: 0755  

--- a/roles/apt/tasks/download_only.yaml
+++ b/roles/apt/tasks/download_only.yaml
@@ -1,15 +1,5 @@
 ---
 
-#-- Note: We may want to remove this so packages from the preseed 
-#--       Debian install are available. Need more info from SLI
-- name: Clean out any existing packages
-  ansible.builtin.apt:
-    clean: yes
-
-- name: Update the cache after cleaning
-  ansible.builtin.apt:
-    update_cache: yes
-
 #-- This is expected to run on a clean system
 #-- Dependencies are then pulled in correctly
 #-- If on an existing system, this can break if 

--- a/scripts/tb-import-from-usb.sh
+++ b/scripts/tb-import-from-usb.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+#-- Gonna run as sudo, so we need the local user 
+local_user=`logname`
+usb_root="/media/${local_user}/VxTrustedBuild"
+
+#-- Make sure the USB is mounted where we expect
+if [ ! -d $usb_root ]; then
+  echo "Error: No USB was found at ${usb_root}"
+  exit 1;
+fi
+
+#-- Set up the various downloads at /tmp/downloads/
+cp -r ${usb_root}/downloads /tmp/
+
+#-- Copy all the apt packages to the local cache
+cp -r ${usb_root}/apt_packages/* /var/cache/apt/archives/
+
+exit 0;

--- a/scripts/tb-import-from-usb.sh
+++ b/scripts/tb-import-from-usb.sh
@@ -3,6 +3,7 @@
 #-- Gonna run as sudo, so we need the local user 
 local_user=`logname`
 usb_root="/media/${local_user}/VxTrustedBuild"
+local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 
 #-- Make sure the USB is mounted where we expect
 if [ ! -d $usb_root ]; then
@@ -15,5 +16,9 @@ cp -r ${usb_root}/downloads /tmp/
 
 #-- Copy all the apt packages to the local cache
 cp -r ${usb_root}/apt_packages/* /var/cache/apt/archives/
+
+#-- Copy vxsuite-complete-system
+cp -r ${usb_root}/vxsuite-complete-system ${local_user_home_dir}/code/
+chown -R ${local_user}.${local_user} ${local_user_home_dir}/code/vxsuite-complete-system
 
 exit 0;

--- a/scripts/tb-install-ansible.sh
+++ b/scripts/tb-install-ansible.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# If no phase, we should just do ALL THE THINGS
-# Dont worry about it yet
-# Check if the phase argument was passed
-
-# Get the phase
 phase=$1
 
 if [ "$phase" != "online" ] && [ "$phase" != "offline" ] && [ "$phase" != "" ]; then
@@ -16,7 +11,6 @@ if [ -z "$1" ]; then
   phase="both"
 fi
 
-# Print a message indicating the phase
 echo "The phase is $phase."
 
 function apt_install ()
@@ -25,6 +19,7 @@ function apt_install ()
   if [ "$phase" == "online" ] || [ "$phase" == "both" ]; then
     echo "online/both"
     apt-get install --reinstall --download-only -y python3.9 python3-pip
+    apt-get install -y python3.9 python3-pip
   fi
 
   if [ "$phase" == "offline" ] || [ "$phase" == "both" ]; then
@@ -39,6 +34,7 @@ function pip_install ()
   if [ "$phase" == "online" ] || [ "$phase" == "both" ]; then
     echo "online/both"
     pip3 download -d /tmp/downloads ansible passlib pipenv 
+    pip3 install --no-index --find-links /tmp/downloads ansible passlib pipenv
   fi
 
   if [ "$phase" == "offline" ] || [ "$phase" == "both" ]; then

--- a/scripts/tb-install-ansible.sh
+++ b/scripts/tb-install-ansible.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# If no phase, we should just do ALL THE THINGS
+# Dont worry about it yet
+# Check if the phase argument was passed
+
+# Get the phase
+phase=$1
+
+if [ "$phase" != "online" ] && [ "$phase" != "offline" ] && [ "$phase" != "" ]; then
+  echo "Error: Invalid phase. Please specify either 'online' or 'offline' or leave blank."
+  exit 1
+fi
+
+if [ -z "$1" ]; then
+  phase="both"
+fi
+
+# Print a message indicating the phase
+echo "The phase is $phase."
+
+function apt_install ()
+{
+  local phase=$1
+  if [ "$phase" == "online" ] || [ "$phase" == "both" ]; then
+    echo "online/both"
+    apt-get install --reinstall --download-only -y python3.9 python3-pip
+  fi
+
+  if [ "$phase" == "offline" ] || [ "$phase" == "both" ]; then
+    echo "offline/both"
+    apt-get install -y python3.9 python3-pip
+  fi
+}
+
+function pip_install ()
+{
+  local phase=$1
+  if [ "$phase" == "online" ] || [ "$phase" == "both" ]; then
+    echo "online/both"
+    pip3 download -d /tmp/downloads ansible passlib pipenv 
+  fi
+
+  if [ "$phase" == "offline" ] || [ "$phase" == "both" ]; then
+    echo "offline/both"
+    pip3 install --no-index --find-links /tmp/downloads ansible passlib pipenv
+  fi
+}
+
+apt_install $phase
+pip_install $phase
+
+echo "Done"
+exit 0


### PR DESCRIPTION
In an effort to minimize the work required to get a VM able to use the Ansible playbooks for trusted build, we provide a basic script for installing Ansible for both the online and offline phases. We also provide a basic script to import from a properly configured USB in the offline phase. 

A sample run of everything required to get a successful run of `playbooks/trusted_build/all.yaml --skip-tags online` on the offline VM is below.

Notes:

-  The repos.yaml playbook will be changed in a separate PR to support calling from the `all.yaml` playbook, but it currently does not and requires being run as described below in the online vm steps.
- The example below assumes a base Debian 11.6 VM built from our pre-seed file. If you don't use our pre-seed, you may need to install `git` and `sudo` before proceeding.

### Online VM steps:
Be sure to insert a USB and confirm it is automatically mounted to the VM before proceeding.
```
mkdir ~/code
cd ~/code
git clone https://github.com/votingworks/vxsuite-build-system.git
cd vxsuite-build-system
git checkout adam/tb-scripts
sudo ./scripts/tb-install-ansible.sh online
ansible-playbook playbooks/trusted_build/all.yaml --skip-tags offline
ansible-playbook playbooks/trusted_build/repos.yaml
ansible-playbook playbooks/trusted_build/export_to_usb.yaml
```
Eject the USB and you are done with the online VM.

### Offline VM steps:
Be sure to insert the USB you created in the online vm and confirm it automatically mounted to the VM before proceeding.
```
mkdir ~/code
cd ~/code
cp -r /media/`logname`/VxTrustedBuild/vxsuite-build-system ~/code/
sudo ./scripts/tb-import-from-usb.sh 
sudo ./scripts/tb-install-ansible.sh offline
ansible-playbook playbooks/trusted_build/all.yaml --skip-tags online
```

### Misc Notes
Playbook changes in this PR are primarily updates to pathing to match our well-known-paths definition. 

The apt role was updated to not clear the apt archive since that introduces a dependency failure when building in the offline VM. I will likely eliminate the role entirely since it's so simple now, and just move the functionality to the playbook.