### PR TITLE
debian 11.7 tpm package fix

### DIFF
--- a/playbooks/trusted_build/tpm.yaml
+++ b/playbooks/trusted_build/tpm.yaml
@@ -15,6 +15,7 @@
       - libtool
       - gcc
       - pkg-config
+      - libltdl-dev
       - libqrencode-dev
       - libssl-dev
       - libjson-c-dev


### PR DESCRIPTION
debian now runs 11.7 even if you pull the 11.6 iso, need to add libltdl-dev for tpm compile