### PR TITLE
Trusted Build hashing updates for Node and Rust

### DIFF
--- a/inventories/tb/group_vars/all/main.yaml
+++ b/inventories/tb/group_vars/all/main.yaml
@@ -10,3 +10,4 @@ vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/pr
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 vm_clone_name: "trusted_build"
+rust_version: "1.68.0"

--- a/inventories/tb/group_vars/all/node.yaml
+++ b/inventories/tb/group_vars/all/node.yaml
@@ -1,4 +1,8 @@
 node_version: "16.19.1"
 npm_packages:
-  - yarn@1.22.15
-  - pnpm@8.1.0
+  yarn:
+    version: "1.22.15"
+    checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
+  pnpm:
+    version: "8.1.0"
+    checksum: "09ebf306075e96037432071992bb00340c263d85"

--- a/inventories/tb/group_vars/all/node.yaml
+++ b/inventories/tb/group_vars/all/node.yaml
@@ -1,0 +1,4 @@
+node_version: "16.19.1"
+npm_packages:
+  - yarn@1.22.15
+  - pnpm@8.1.0

--- a/playbooks/trusted_build/node.yaml
+++ b/playbooks/trusted_build/node.yaml
@@ -48,6 +48,10 @@
             url: "{{ release_url }}"
             dest: "{{ downloads_directory }}/node-{{ node_version }}.tar.gz"
             checksum: "sha256:{{ node_checksum.stdout }}"
+          retries: 3
+          delay: 2
+          register: node_download
+          until: node_download is not failed
           tags:
             - online
 

--- a/playbooks/trusted_build/node.yaml
+++ b/playbooks/trusted_build/node.yaml
@@ -70,7 +70,7 @@
         - name: Verify downloaded packages match expected checksums
           ansible.builtin.fail:
             msg: "Error! The checksum for {{ item }} does not match."
-          when: item.stdout != npm_packages[item].checksum
+          when: item.stat.checksum != npm_packages[item.item.key].checksum
           loop: "{{ npm_package_checksums.results }}"
 
         - name: See if corepack is present

--- a/playbooks/trusted_build/node.yaml
+++ b/playbooks/trusted_build/node.yaml
@@ -1,4 +1,13 @@
 ---
+#-- NOTE: We verify checksums in two ways in this playbook
+#-- For Node: the checksum is checked against the value provided
+#-- by the official NodeJS distribution
+#-- 
+#-- For NPM packages, we retrieve the checksum manually and define
+#-- it in Ansible inventories, as appropriate
+#-- To retrieve a checksum from the official NPM Registry, use:
+#-- npm pack --dry-run <package>@<version>
+#-- You will see the shasum value near the end of the output
 - name: Manage Node Install
   hosts: 127.0.0.1
   connection: local
@@ -67,7 +76,7 @@
           with_dict: "{{ npm_packages }}"
           register: npm_package_checksums
 
-        - name: Verify downloaded packages match expected checksums
+        - name: Error and exit if checksums are not valid (skipping is good)
           ansible.builtin.fail:
             msg: "Error! The checksum for {{ item }} does not match."
           when: item.stat.checksum != npm_packages[item.item.key].checksum

--- a/playbooks/trusted_build/node.yaml
+++ b/playbooks/trusted_build/node.yaml
@@ -56,10 +56,22 @@
             - always
 
         - name: Download package managers
-          command: "npm pack --pack-destination {{ downloads_directory }} {{ item }}"
-          loop: "{{ npm_packages }}"
+          command: "npm pack --pack-destination {{ downloads_directory }} {{ item.key }}@{{ item.value.version }}"
+          with_dict: "{{ npm_packages }}"
           tags:
             - online
+
+        - name: Generate checksums of downloaded package managers
+          ansible.builtin.stat:
+            path: "{{ downloads_directory }}/{{ item.key }}-{{ item.value.version }}.tgz"
+          with_dict: "{{ npm_packages }}"
+          register: npm_package_checksums
+
+        - name: Verify downloaded packages match expected checksums
+          ansible.builtin.fail:
+            msg: "Error! The checksum for {{ item }} does not match."
+          when: item.stdout != npm_packages[item].checksum
+          loop: "{{ npm_package_checksums.results }}"
 
         - name: See if corepack is present
           command: "which corepack"

--- a/playbooks/trusted_build/node.yaml
+++ b/playbooks/trusted_build/node.yaml
@@ -4,18 +4,14 @@
   connection: local
   become: true
 
-  #-- TODO: move downloads_directory to defaults/inventory
-  vars:
-    downloads_directory: "/var/tmp/downloads"
-    node_version: "16.19.1"
-    npm_packages:
-      - yarn@1.22.15
-      - pnpm@8.1.0
-
   tasks:
 
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
+
+    - name: Define downloads_directory from well_known_paths
+      set_fact:
+        downloads_directory: "{{ well_known_paths['tools']['system_path'] }}"
 
     - name: Determine system architecture
       set_fact:
@@ -33,10 +29,16 @@
           set_fact:
             release_url: "https://nodejs.org/dist/v{{ node_version }}/node-v{{ node_version }}-linux-{{ architecture }}.tar.gz"
 
+        - name: Find the appropriate checksum for the download
+          ansible.builtin.shell:
+            cmd: "curl --silent https://nodejs.org/dist/v{{ node_version }}/SHASUMS256.txt | grep node-v{{ node_version }}-linux-{{ architecture }}.tar.gz | cut -d' ' -f1"
+          register: node_checksum
+
         - name: Download Node tarball
           ansible.builtin.get_url:
             url: "{{ release_url }}"
             dest: "{{ downloads_directory }}/node-{{ node_version }}.tar.gz"
+            checksum: "sha256:{{ node_checksum.stdout }}"
           tags:
             - online
 

--- a/playbooks/trusted_build/node.yaml
+++ b/playbooks/trusted_build/node.yaml
@@ -87,8 +87,8 @@
             - offline
 
         - name: Install package managers
-          command: "npm install -g {{ downloads_directory }}/{{ item | replace('@', '-') }}.tgz"
-          loop: "{{ npm_packages }}"
+          command: "npm install -g {{ downloads_directory }}/{{ item.key }}-{{ item.value.version }}.tgz"
+          with_dict: "{{ npm_packages }}"
           tags:
             - offline
 

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -5,7 +5,7 @@
   become: yes
 
   vars:
-    downloads_directory: "/var/tmp/code"
+    tmp_code_directory: "/var/tmp/code"
     user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
     code_directory: "~{{ user_to_configure }}/code"
 
@@ -26,21 +26,21 @@
     - name: Online tasks for git repos
       block:
 
-      - name: Make sure the {{ downloads_directory }} directory does not exist from a previous build
+      - name: Make sure the {{ tmp_code_directory }} directory does not exist from a previous build
         ansible.builtin.file:
-          path: "{{ downloads_directory }}"
+          path: "{{ tmp_code_directory }}"
           state: absent
-        when: (downloads_directory is defined) and (downloads_directory|length > 0)
+        when: (tmp_code_directory is defined) and (tmp_code_directory|length > 0)
 
       - name: Create the code subdir
         ansible.builtin.file:
-          path: "{{ downloads_directory }}"
+          path: "{{ tmp_code_directory }}"
           state: directory
           mode: '0755'
   
       - name: Create the repo subdirs in the code dir
         ansible.builtin.file:
-          path: "{{ downloads_directory }}/{{ item.key }}"
+          path: "{{ tmp_code_directory }}/{{ item.key }}"
           state: directory
           mode: '0755'
         with_dict: "{{ repos }}"
@@ -51,7 +51,7 @@
       - name: Clone the votingworks repos
         ansible.builtin.git:
           repo: "https://github.com/votingworks/{{ item.key }}.git"
-          dest: "{{ downloads_directory }}/{{ item.key }}"
+          dest: "{{ tmp_code_directory }}/{{ item.key }}"
           version: "{{ item.value.version | default('main') }}"
         with_dict: "{{ repos }}"
 
@@ -61,14 +61,14 @@
     #-- TODO: Should this just be part of an initial script copy instead?
     - name: Offline tasks for git repos
       block:
-        - name: Check that the expected {{ downloads_directory }} directory exists
+        - name: Check that the expected {{ tmp_code_directory }} directory exists
           ansible.builtin.stat:
-            path: "{{ downloads_directory }}"
+            path: "{{ tmp_code_directory }}"
           register: code_dir_info
 
-        - name: Error if {{ downloads_directory }} does not exist
+        - name: Error if {{ tmp_code_directory }} does not exist
           ansible.builtin.fail:
-            msg: "Error: The expected {{ downloads_directory }} directory does not exist."
+            msg: "Error: The expected {{ tmp_code_directory }} directory does not exist."
           when: not code_dir_info.stat.exists or not code_dir_info.stat.isdir
 
         - name: Create the {{ code_directory }} directory
@@ -91,9 +91,9 @@
           when: item.stat.exists
           with_items: "{{ repos_info.results }}"
 
-        - name: Copy {{ downloads_directory }} to {{ code_directory }}
+        - name: Copy {{ tmp_code_directory }} to {{ code_directory }}
           ansible.builtin.copy:
-            src: "{{ downloads_directory }}/"
+            src: "{{ tmp_code_directory }}/"
             dest: "{{ code_directory }}"
             remote_src: yes
             owner: "{{ user_to_configure }}"

--- a/playbooks/trusted_build/rust.yaml
+++ b/playbooks/trusted_build/rust.yaml
@@ -1,25 +1,34 @@
 ---
+#-- NOTE: Rust uses gpg for verification of the downloaded installer
+#-- We'll be using that rather than checksums in this playbook
 - name: Trusted Build Install of Rust
   hosts: 127.0.0.1
   connection: local
   become: true
-
-  vars:
-    downloads_directory: "/var/tmp/downloads"
-    rust_version: '1.68.0'
 
   tasks:
 
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
 
+
+    - name: Define downloads_directory from well_known_paths
+      set_fact:
+        downloads_directory: "{{ well_known_paths['tools']['system_path'] }}"
+
     - name: Determine system architecture for appropriate Rust install
       set_fact: 
         architecture: "{{ 'aarch64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x86_64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
 
-    - name: Set the URL to download the appropriate Rust tarball
+    - name: Define the URL to download the appropriate Rust tarball
       set_fact:
         rust_tarball_url: "https://static.rust-lang.org/dist/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+      tags:
+        - online
+
+    - name: Define URL to Rust signing key
+      set_fact:
+        rust_signing_key_url: "https://static.rust-lang.org/rust-key.gpg.ascii"
       tags:
         - online
 
@@ -34,6 +43,19 @@
         dest: "{{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
       tags:
         - online
+
+    - name: Download Rust signing key
+      ansible.builtin.get_url:
+        url: "{{ rust_signing_key_url }}"
+        dest: "{{ downloads_directory }}/rust-key.gpg.ascii"
+      tags:
+        - online
+
+    - name: Check for a valid signature and exit if it fails
+      ansible.builtin.shell: 
+        cmd: "/usr/bin/gpg --verify {{ downloads_directory }}/rust-key.gpg.ascii {{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+      register: rust_signature_check
+      failed_when: rust_signature_check.rc != 0
 
     - name: Extract Rust to tmp
       ansible.builtin.unarchive:

--- a/playbooks/trusted_build/rust.yaml
+++ b/playbooks/trusted_build/rust.yaml
@@ -19,15 +19,23 @@
       set_fact: 
         architecture: "{{ 'aarch64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x86_64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
 
+    - name: Define Rust tarball name
+      set_fact: 
+        rust_tarball: "rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+
+    - name: Define Rust manifest name
+      set_fact: 
+        rust_manifest: "channel-rust-{{ rust_version }}.toml"
+
     - name: Define the URL to download the appropriate Rust tarball
       set_fact:
-        rust_tarball_url: "https://static.rust-lang.org/dist/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+        rust_tarball_url: "https://static.rust-lang.org/dist/{{ rust_tarball }}"
       tags:
         - online
 
     - name: Define URL to Rust channel manifest for this version
       set_fact:
-        rust_manifest_url: "https://static.rust-lang.org/dist/channel-rust-{{ rust_version }}.toml"
+        rust_manifest_url: "https://static.rust-lang.org/dist/{{ rust_manifest }}"
       tags:
         - online
 
@@ -39,26 +47,26 @@
     - name: Download Rust
       ansible.builtin.get_url:
         url: "{{ rust_tarball_url }}"
-        dest: "{{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+        dest: "{{ downloads_directory }}/{{ rust_tarball }}"
       tags:
         - online
 
     - name: Download Rust channel manifest for this version
       ansible.builtin.get_url:
         url: "{{ rust_manifest_url }}"
-        dest: "{{ downloads_directory }}/rust-{{ rust_version }}.toml"
+        dest: "{{ downloads_directory }}/{{ rust_manifest }}"
       tags:
         - online
 
     - name: Find the sha256 hash for our version
       ansible.builtin.shell:
-        cmd: "grep -A1 rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz {{ downloads_directory }}/rust-{{ rust_version }}.toml | grep hash | cut -d'=' -f2 | xargs"
+        cmd: "grep -A1 {{ rust_tarball }} {{ downloads_directory }}/{{ rust_manifest }} | grep hash | cut -d'=' -f2 | xargs"
       register: rust_checksum_from_manifest
 
     - name: Generate checksum of the downloaded Rust installer
       ansible.builtin.stat:
         checksum_algorithm: "sha256"
-        path: "{{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+        path: "{{ downloads_directory }}/{{ rust_tarball }}"
       register: rust_checksum_from_download
 
     - name: Error and exit if checksums are not valid (skipping is good)
@@ -68,7 +76,7 @@
 
     - name: Extract Rust to tmp
       ansible.builtin.unarchive:
-        src: "{{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+        src: "{{ downloads_directory }}/{{ rust_tarball }}"
         dest: /var/tmp
         remote_src: yes
       become: true

--- a/playbooks/trusted_build/rust.yaml
+++ b/playbooks/trusted_build/rust.yaml
@@ -48,6 +48,10 @@
       ansible.builtin.get_url:
         url: "{{ rust_tarball_url }}"
         dest: "{{ downloads_directory }}/{{ rust_tarball }}"
+      retries: 3
+      delay: 2
+      register: rust_download
+      until: rust_download is not failed
       tags:
         - online
 

--- a/playbooks/trusted_build/rust.yaml
+++ b/playbooks/trusted_build/rust.yaml
@@ -57,6 +57,7 @@
 
     - name: Generate checksum of the downloaded Rust installer
       ansible.builtin.stat:
+        checksum_algorithm: "sha256"
         path: "{{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
       register: rust_checksum_from_download
 

--- a/playbooks/trusted_build/rust.yaml
+++ b/playbooks/trusted_build/rust.yaml
@@ -1,6 +1,6 @@
 ---
-#-- NOTE: Rust uses gpg for verification of the downloaded installer
-#-- We'll be using that rather than checksums in this playbook
+#-- NOTE: Rust standalone installers do not support gpg validation any more
+#-- sha256 checksums are provided though via a manifest provided for each version
 - name: Trusted Build Install of Rust
   hosts: 127.0.0.1
   connection: local
@@ -10,7 +10,6 @@
 
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
-
 
     - name: Define downloads_directory from well_known_paths
       set_fact:
@@ -26,9 +25,9 @@
       tags:
         - online
 
-    - name: Define URL to Rust signing key
+    - name: Define URL to Rust channel manifest for this version
       set_fact:
-        rust_signing_key_url: "https://static.rust-lang.org/rust-key.gpg.ascii"
+        rust_manifest_url: "https://static.rust-lang.org/dist/channel-rust-{{ rust_version }}.toml"
       tags:
         - online
 
@@ -44,18 +43,27 @@
       tags:
         - online
 
-    - name: Download Rust signing key
+    - name: Download Rust channel manifest for this version
       ansible.builtin.get_url:
-        url: "{{ rust_signing_key_url }}"
-        dest: "{{ downloads_directory }}/rust-key.gpg.ascii"
+        url: "{{ rust_manifest_url }}"
+        dest: "{{ downloads_directory }}/rust-{{ rust_version }}.toml"
       tags:
         - online
 
-    - name: Check for a valid signature and exit if it fails
-      ansible.builtin.shell: 
-        cmd: "/usr/bin/gpg --verify {{ downloads_directory }}/rust-key.gpg.ascii {{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
-      register: rust_signature_check
-      failed_when: rust_signature_check.rc != 0
+    - name: Find the sha256 hash for our version
+      ansible.builtin.shell:
+        cmd: "grep -A1 rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz {{ downloads_directory }}/rust-{{ rust_version }}.toml | grep hash | cut -d'=' -f2 | xargs"
+      register: rust_checksum_from_manifest
+
+    - name: Generate checksum of the downloaded Rust installer
+      ansible.builtin.stat:
+        path: "{{ downloads_directory }}/rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+      register: rust_checksum_from_download
+
+    - name: Error and exit if checksums are not valid (skipping is good)
+      ansible.builtin.fail:
+        msg: "Error! The checksum for the Rust installer does not match."
+      when: rust_checksum_from_manifest.stdout != rust_checksum_from_download.stat.checksum
 
     - name: Extract Rust to tmp
       ansible.builtin.unarchive:


### PR DESCRIPTION
This PR adds checksum verification to our installs of: Node, pnpm, yarn, and Rust. I've included several ways of handling checksums, generally based on the tool, but also to give us options based on trusted build hashing requirements. 

Of note and up for discussion:

- Node obtains the checksum in a single command, does not store it on the local filesystem, but uses it for the download. It relies on built-in Ansible functionality that will fail the download if the checksum does not match.
- pnpm and yarn rely on the NPM ecosystem's implementation of checksums. Rather than publishing them separately, they are included within packages and most easily obtained via the npm command itself. This presents an interesting situation where the community relies on the tool itself to verify each package. 
- Rust is using fairly traditional sha256 checksum verification, because the documented GPG solution is not actually supported in standalone installers any longer. The online install tools use a new method, but offline installers are limited to inspecting a version manifest and extracting the appropriate checksum to compare against.