### PR TITLE
Misc fixes for trusted build process

### DIFF
--- a/inventories/deb12/group_vars/all/main.yaml
+++ b/inventories/deb12/group_vars/all/main.yaml
@@ -9,5 +9,7 @@ iso_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
-vm_clone_name: "deb12"
 rust_version: "1.72.0"
+cloned_images:
+  - online
+  - offline

--- a/inventories/deb12/group_vars/all/packages.yaml
+++ b/inventories/deb12/group_vars/all/packages.yaml
@@ -1,4 +1,6 @@
 ---
+batch_package_install: true
+
 all_packages:
   - alsa-utils=1.2.8-1
   - brightnessctl=0.5.1-3

--- a/inventories/deb12/group_vars/all/packages.yaml
+++ b/inventories/deb12/group_vars/all/packages.yaml
@@ -92,4 +92,3 @@ tpm_packages:
   - qrencode=4.1.1-1
   - tpm2-openssl=1.1.1-1
   - tpm2-tools=5.4-1
-  - tpm-udev=0.6

--- a/inventories/tb/group_vars/all/packages.yaml
+++ b/inventories/tb/group_vars/all/packages.yaml
@@ -1,4 +1,6 @@
 ---
+batch_package_install: true
+
 all_packages:
   - alsa-utils=1.2.4-1
   - brightnessctl=0.5.1-3

--- a/playbooks/install-vxsuite-packages.yaml
+++ b/playbooks/install-vxsuite-packages.yaml
@@ -97,8 +97,5 @@
         all_packages: "{{ all_packages | unique | select | list }}"
 
     - name: Install all necessary system packages
-      package:
-        name: "{{ item }}"
-        state: latest
-      with_items: 
-        - "{{ all_packages }}"
+      ansible.builtin.command:
+        cmd: "apt-get -y --no-install-recommends install {{ all_packages | join(' ') }}"

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -4,13 +4,10 @@
   connection: local
   become: yes
 
-#-- Note: firewalld comes first because it will prevent all external
-#-- network requests, regardless of whether the VM has networking
-#-- enabled or not
-- import_playbook: firewalld.yaml
 - import_playbook: packages.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml
 - import_playbook: rubygems.yaml
 - import_playbook: tpm.yaml
+- import_playbook: firewalld.yaml
 - import_playbook: disable_services.yaml

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -4,10 +4,13 @@
   connection: local
   become: yes
 
+#-- Note: firewalld comes first because it will prevent all external
+#-- network requests, regardless of whether the VM has networking
+#-- enabled or not
+- import_playbook: firewalld.yaml
 - import_playbook: packages.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml
 - import_playbook: rubygems.yaml
 - import_playbook: tpm.yaml
-- import_playbook: firewalld.yaml
 - import_playbook: disable_services.yaml

--- a/playbooks/virtmanager/clone-base-vm.yaml
+++ b/playbooks/virtmanager/clone-base-vm.yaml
@@ -4,39 +4,22 @@
 
   tasks:
 
-    - name: See if the {{ vm_clone_name }} VM already exists
+    - name: See if the {{ item }} VM already exists
       shell:
-        cmd: virsh dominfo {{ vm_clone_name }}
+        cmd: virsh dominfo {{ item }}
       register: does_vm_exist
       changed_when: no
       ignore_errors: true
+      loop: "{{ cloned_images }}"
 
     - name: Clone VM
       command: >
         virt-clone 
         -o {{ vm_name }} 
-        -n {{ vm_clone_name }} 
+        -n {{ item.item }} 
         --auto-clone 
         --check disk_size=off
       register: clone_status
-      when: does_vm_exist.rc != 0
-
-   #- name: Generate keypair
-     #community.crypto.openssh_keypair:
-       #path: /tmp/id_rsa
-       #size: 2048
-       #become: true
-       #become_user: "vx"
-
-   #- debug:
-      #var: clone_status
-
-   #- name: Inject the ssh key for future access
-     #command: >
-       #virt-sysprep
-       #-a {{ image_path }}/{{ vm_clone_name }}.qcow2
-       #--ssh-inject vx:file:/tmp/id_rsa.pub
-       #--run-command 'cd /etc/ssh; ssh-keygen -A'
-     #when: does_vm_exist.rc == 0 or clone_status.rc == 0
-
+      when: item.rc != 0
+      loop: "{{ does_vm_exist.results }}"
 

--- a/playbooks/virtmanager/clone-base-vm.yaml
+++ b/playbooks/virtmanager/clone-base-vm.yaml
@@ -23,16 +23,19 @@
       when: item.rc != 0
       loop: "{{ does_vm_exist.results }}"
 
-    - name: Disable networking in offline VM if it exists
-      ansible.builtin.replace:
+    - name: Check for offline VM xml definition
+      ansible.builtin.stat:
         path: "/etc/libvirt/qemu/offline.xml"
-        regexp: '\s+<link state=.*'
-        replace: "<link state='down'/>"
-      when: (item.rc == 0) and (item.item == "offline")
-      loop: "{{ does_vm_exist.results }}"
+      register: offline_xml
+
+    - name: Disable networking in offline VM if it exists
+      ansible.builtin.lineinfile:
+        path: "/etc/libvirt/qemu/offline.xml"
+        insertafter: "<interface type='bridge'>"
+        line: "  <link state='down'/>"
+      when: offline_xml.stat.exists and offline_xml.stat.isreg
 
     - name: Update the offline VM from new XML definition
       ansible.builtin.command:
         cmd: "virsh define /etc/libvirt/qemu/offline.xml"
-      when: (item.rc == 0) and (item.item == "offline")
-      loop: "{{ does_vm_exist.results }}"
+      when: offline_xml.stat.exists and offline_xml.stat.isreg

--- a/playbooks/virtmanager/clone-base-vm.yaml
+++ b/playbooks/virtmanager/clone-base-vm.yaml
@@ -23,3 +23,16 @@
       when: item.rc != 0
       loop: "{{ does_vm_exist.results }}"
 
+    - name: Disable networking in offline VM if it exists
+      ansible.builtin.replace:
+        path: "/etc/libvirt/qemu/offline.xml"
+        regexp: '\s+<link state=.*'
+        replace: "<link state='down'/>"
+      when: (item.rc == 0) and (item.item == "offline")
+      loop: "{{ does_vm_exist.results }}"
+
+    - name: Update the offline VM from new XML definition
+      ansible.builtin.command:
+        cmd: "virsh define /etc/libvirt/qemu/offline.xml"
+      when: (item.rc == 0) and (item.item == "offline")
+      loop: "{{ does_vm_exist.results }}"

--- a/preseeds/production-preseed.cfg
+++ b/preseeds/production-preseed.cfg
@@ -482,7 +482,7 @@ d-i finish-install/reboot_in_progress note
 # reboot into the installed system.
 #d-i debian-installer/exit/halt boolean true
 # This will power off the machine instead of just halting it.
-#d-i debian-installer/exit/poweroff boolean true
+d-i debian-installer/exit/poweroff boolean true
 
 ### Preseeding other packages
 # Depending on what software you choose to install, or if things go wrong
@@ -515,5 +515,4 @@ d-i finish-install/reboot_in_progress note
 # still a usable /target directory. You can chroot to /target and use it
 # directly, or use the apt-install and in-target commands to easily install
 # packages and run commands in the target system.
-#d-i preseed/late_command string apt-install zsh; in-target chsh -s /bin/zsh
 

--- a/roles/apt/tasks/download_only.yaml
+++ b/roles/apt/tasks/download_only.yaml
@@ -4,9 +4,17 @@
 #-- Dependencies are then pulled in correctly
 #-- If on an existing system, this can break if 
 #-- a dependency is already installed
-#-- TODO: Make it work on pre-existing systems???
+
+#-- This is the slow but more verbase package install
+#-- Probably what we want to use for Trusted Build for clarity
 - name: Download the packages and dependencies
   ansible.builtin.command:
     cmd: "apt-get install --reinstall --no-install-recommends --download-only -y {{ item }}"
   with_items:
     - "{{ all_packages }}"
+  when: (batch_package_install is not defined) or (batch_package_install is false)
+
+- name: Download the packages and dependencies (fast)
+  ansible.builtin.command:
+    cmd: "apt-get install --reinstall --no-install-recommends --download-only -y {{ all_packages | join(' ') }}"
+  when: (batch_package_install is defined) and (batch_package_install is true)

--- a/roles/apt/tasks/download_only.yaml
+++ b/roles/apt/tasks/download_only.yaml
@@ -7,14 +7,14 @@
 
 #-- This is the slow but more verbase package install
 #-- Probably what we want to use for Trusted Build for clarity
-- name: Download the packages and dependencies
+- name: Download the packages and dependencies (single)
   ansible.builtin.command:
     cmd: "apt-get install --reinstall --no-install-recommends --download-only -y {{ item }}"
   with_items:
     - "{{ all_packages }}"
   when: (batch_package_install is not defined) or (batch_package_install is false)
 
-- name: Download the packages and dependencies (fast)
+- name: Download the packages and dependencies (batch)
   ansible.builtin.command:
     cmd: "apt-get install --reinstall --no-install-recommends --download-only -y {{ all_packages | join(' ') }}"
   when: (batch_package_install is defined) and (batch_package_install is true)

--- a/roles/apt/tasks/main.yaml
+++ b/roles/apt/tasks/main.yaml
@@ -4,7 +4,7 @@
   tags:
     - online
 
-- name: Install the packages
+- name: Install the packages (single)
   ansible.builtin.apt:
     name: "{{ item }}"
     install_recommends: false
@@ -15,7 +15,7 @@
   tags:
     - offline
 
-- name: Install the packages (fast)
+- name: Install the packages (batch)
   ansible.builtin.command:
     cmd: "apt-get -y --no-install-recommends install {{ all_packages | join(' ') }}"
   when: (batch_package_install is defined) and (batch_package_install is true)

--- a/roles/apt/tasks/main.yaml
+++ b/roles/apt/tasks/main.yaml
@@ -11,6 +11,13 @@
     state: present
   with_items:
     - "{{ all_packages }}"
+  when: (batch_package_install is defined) and (batch_package_install is true)
   tags:
     - offline
 
+- name: Install the packages (fast)
+  ansible.builtin.command:
+    cmd: "apt-get -y --no-install-recommends install {{ all_packages | join(' ') }}"
+  when: (batch_package_install is defined) and (batch_package_install is true)
+  tags:
+    - offline

--- a/roles/apt/tasks/main.yaml
+++ b/roles/apt/tasks/main.yaml
@@ -11,7 +11,7 @@
     state: present
   with_items:
     - "{{ all_packages }}"
-  when: (batch_package_install is defined) and (batch_package_install is true)
+  when: (batch_package_install is not defined) or (batch_package_install is false)
   tags:
     - offline
 

--- a/scripts/tb-clone-images.sh
+++ b/scripts/tb-clone-images.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ansible_inventory=$1
+debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
+local_user=`logname`
+local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
+vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
+vxsuite_complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
+
+if [[ ! -d ${vxsuite_build_system_dir}/inventories/${ansible_inventory} ]]; then
+  echo "ERROR: The $ansible_inventory inventory could not be found."
+  echo "You can find a list of inventories in: ${vxsuite_build_system_dir}/inventories"
+  exit 1
+fi
+
+if [[ ! -d $vxsuite_build_system_dir ]]; then
+  echo "ERROR: vxsuite-build-system could not be found."
+  exit 1
+fi
+
+if ! which ansible-playbook > /dev/null 2>&1
+then
+  echo "Installing Ansible..."
+  cd $vxsuite_build_system_dir
+  sudo ./scripts/tb-install-ansible.sh
+  echo "Ansible installation is complete."
+fi
+
+cd $vxsuite_build_system_dir
+
+if [[ "$debian_major_version" == "12" ]]; then
+  source .virtualenv/ansible/bin/activate
+fi
+
+echo "Clone the online and offline images"
+sleep 5
+ansible-playbook -i inventories/${ansible_inventory} playbooks/virtmanager/clone-base-vm.yaml
+
+exit 0

--- a/scripts/tb-export-to-usb.sh
+++ b/scripts/tb-export-to-usb.sh
@@ -6,7 +6,6 @@ debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
 local_user=`logname`
 local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
-vxsuite_complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
 
 ansible_inventory=$1
 
@@ -35,26 +34,8 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
-echo "Run prepare_for_build playbook. This will take several minutes."
+echo "Export VotingWorks tools and repositories to USB"
 sleep 5
-ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/prepare_for_build.yaml
-
-if [[ ! -d $vxsuite_complete_system_dir ]]; then
-  echo "ERROR: vxsuite-complete-system could not be found."
-  exit 1
-fi
-
-echo "Run prepare_build.sh in complete-system. This will take several minutes."
-sleep 5
-cd $vxsuite_complete_system_dir
-./prepare_build.sh
-
-echo "Download necessary tools for TPM."
-sleep 5
-cd $vxsuite_build_system_dir
-ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/tpm.yaml --skip-tags offline
-
-echo "The online phase is complete. Please insert a USB drive and run: "
-echo "./scripts/tb-export-to-usb.sh ${ansible_inventory}"
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/export_to_usb.yaml
 
 exit 0

--- a/scripts/tb-import-from-usb.sh
+++ b/scripts/tb-import-from-usb.sh
@@ -35,27 +35,27 @@ cp -r ${usb_root}/apt_packages/* /var/cache/apt/archives/
 
 if [ ! -d $code_dir ]; then
   mkdir -p $code_dir
-  chown ${local_user}.${local_user} $code_dir
+  chown ${local_user}:${local_user} $code_dir
 fi
 
 #-- Copy vxsuite-complete-system
 echo "Copying vxsuite-complete-system code repository"
 cp -r ${usb_root}/vxsuite-complete-system $code_dir
-chown -R ${local_user}.${local_user} ${code_dir}/vxsuite-complete-system
+chown -R ${local_user}:${local_user} ${code_dir}/vxsuite-complete-system
 
 #-- Copy vxsuite-build-system
 echo "Copying vxsuite-build-system code repository"
 cp -r ${usb_root}/vxsuite-build-system $code_dir
-chown -R ${local_user}.${local_user} ${code_dir}/vxsuite-build-system
+chown -R ${local_user}:${local_user} ${code_dir}/vxsuite-build-system
 
 #-- Copy cargo packages
 echo "Copying cargo crates (Rust)"
 if [ ! -d $cargo_dir ]; then
   mkdir -p $cargo_dir
-  chown -R ${local_user}.${local_user} ${local_user_home_dir}/.cargo
+  chown -R ${local_user}:${local_user} ${local_user_home_dir}/.cargo
 fi
 cp -r ${usb_root}/cargo_packages/* $cargo_dir
-chown -R ${local_user}.${local_user} $cargo_dir
+chown -R ${local_user}:${local_user} $cargo_dir
 
 #-- Copy pnpm packages
 echo "Copying pnpm modules (Node)"
@@ -63,33 +63,33 @@ if [ ! -d $pnpm_dir ]; then
   mkdir -p $pnpm_dir
 fi
 cp -r ${usb_root}/pnpm_packages/* $pnpm_dir
-chown -R ${local_user}.${local_user} $pnpm_dir
+chown -R ${local_user}:${local_user} $pnpm_dir
 
 #-- Copy electron cache
 echo "Copying Electron cache and related tools"
 if [ ! -d $electron_dir ]; then
   mkdir -p $electron_dir
-  chown -R ${local_user}.${local_user} $electron_dir
+  chown -R ${local_user}:${local_user} $electron_dir
 fi
 cp -r ${usb_root}/electron_cache/* $electron_dir
-chown -R ${local_user}.${local_user} $electron_dir
+chown -R ${local_user}:${local_user} $electron_dir
 
 #-- Copy electron-gyp cache
 if [ ! -d $electron_gyp_dir ]; then
   mkdir -p $electron_gyp_dir
-  chown -R ${local_user}.${local_user} $electron_gyp_dir
+  chown -R ${local_user}:${local_user} $electron_gyp_dir
 fi
 cp -r ${usb_root}/electron_gyp_cache/* $electron_gyp_dir
-chown -R ${local_user}.${local_user} $electron_gyp_dir
+chown -R ${local_user}:${local_user} $electron_gyp_dir
 
 #-- Copy yarn cache
 echo "Copying yarn cache"
 if [ ! -d $yarn_dir ]; then
   mkdir -p $yarn_dir
-  chown -R ${local_user}.${local_user} $yarn_dir
+  chown -R ${local_user}:${local_user} $yarn_dir
 fi
 cp -r ${usb_root}/yarn_cache/* $yarn_dir
-chown -R ${local_user}.${local_user} $yarn_dir
+chown -R ${local_user}:${local_user} $yarn_dir
 
 echo "All resources required for building have been copied to the correct locations."
 echo "Please run: "

--- a/scripts/tb-import-from-usb.sh
+++ b/scripts/tb-import-from-usb.sh
@@ -94,7 +94,7 @@ chown -R ${local_user}:${local_user} $yarn_dir
 echo "All resources required for building have been copied to the correct locations."
 echo "Please run: "
 echo ""
-echo "cd ${code_dir}/vxsuite-build-system && ./scripts/tb-run-offline-phase.sh"
+echo "cd ${code_dir}/vxsuite-build-system && ./scripts/tb-run-offline-phase.sh <inventory name>"
 echo ""
 
 exit 0;

--- a/scripts/tb-initialize-build-machine.sh
+++ b/scripts/tb-initialize-build-machine.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ansible_inventory=$1
+debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
+local_user=`logname`
+local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
+vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
+vxsuite_complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
+
+if [[ ! -d ${vxsuite_build_system_dir}/inventories/${ansible_inventory} ]]; then
+  echo "ERROR: The $ansible_inventory inventory could not be found."
+  echo "You can find a list of inventories in: ${vxsuite_build_system_dir}/inventories"
+  exit 1
+fi
+
+if [[ ! -d $vxsuite_build_system_dir ]]; then
+  echo "ERROR: vxsuite-build-system could not be found."
+  exit 1
+fi
+
+if ! which ansible-playbook > /dev/null 2>&1
+then
+  echo "Installing Ansible..."
+  cd $vxsuite_build_system_dir
+  sudo ./scripts/tb-install-ansible.sh
+  echo "Ansible installation is complete."
+fi
+
+cd $vxsuite_build_system_dir
+
+if [[ "$debian_major_version" == "12" ]]; then
+  source .virtualenv/ansible/bin/activate
+fi
+
+echo "Install virt-manager tools"
+sleep 5
+ansible-playbook -i inventories/${ansible_inventory} playbooks/virtmanager/install-virt-manager.yaml
+
+echo "Create the base Debian image"
+sleep 5
+ansible-playbook -i inventories/${ansible_inventory} playbooks/virtmanager/create-base-vm.yaml
+
+exit 0

--- a/scripts/tb-install-ansible.sh
+++ b/scripts/tb-install-ansible.sh
@@ -12,6 +12,7 @@ fi
 
 debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
 system_architecture=$(uname -m)
+local_user=`logname`
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/scripts/tb-install-ansible.sh
+++ b/scripts/tb-install-ansible.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-phase=$1
+default_phase="online"
+phase=${1:-$default_phase}
 
 if [ "$phase" != "online" ] && [ "$phase" != "offline" ]; then
   echo "Error: Invalid phase. Please specify either 'online' or 'offline'."
@@ -39,6 +40,7 @@ function pip_install ()
   local pip_requirements="${DIR}/pip_deb${debian_major_version}_${system_architecture}_requirements.txt"
 
   if [[ "$debian_major_version" == "12" ]]; then
+    cd ${DIR}/..
     mkdir -p .virtualenv
     cd .virtualenv && virtualenv ansible
     cd ..
@@ -52,6 +54,13 @@ function pip_install ()
 
   if [ "$phase" == "offline" ]; then
     pip3 install --no-index --find-links /var/tmp/downloads --require-hashes -r $pip_requirements
+  fi
+
+  # We need to make sure the local user's virtualenv isn't owned by root
+  # so that complete-system setup-machine can delete it
+  if [[ "$debian_major_version" == "12" ]]; then
+    cd ${DIR}/..
+    chown -R ${local_user}:${local_user} .virtualenv   
   fi
 }
 


### PR DESCRIPTION
Misc fixes and quality of life changes for the trusted build process. Of note:

- The offline VM is having networking disabled as part of the clone operation. The XML definition is edited, then the newly created VM is re-defined with that setting changed. 
- Added the option for batching package downloads/installs. It's faster but less verbose. 
- Convenience scripts to replace directly calling more convoluted ansible commands
- An attempt to automatically shut down the base VM after creation. It does not reliably work w/ virt-manager though.