### PR TITLE
Disable default virt-install reboot

### DIFF
--- a/playbooks/virtmanager/create-base-vm.yaml
+++ b/playbooks/virtmanager/create-base-vm.yaml
@@ -42,6 +42,7 @@
         --ram={{ vm_ram }}
         --vcpus={{ vm_cpus }}
         --osinfo linux2022
+        --noreboot
         --location={{ virt_image_path }}/{{ iso_name }}
         --network bridge=virbr0,model=virtio
         {{ '--boot loader=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd,loader.readonly=yes,loader.type=pflash,loader.secure=yes' if ( secure_boot ) else ' ' }}


### PR DESCRIPTION
By default, virt-install reboots VMs. We don't want that since it interferes with our preseed configuration. This forces virt-install to not reboot after the install completes so the preseed poweroff directive works