### PR TITLE
build(zbar): add `libzbar-dev` package

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -39,6 +39,7 @@ all_packages:
   - libx11-dev=2:1.8.4-2+deb12u1
   - libxss1=1:1.2.3-1
   - libxtst6=2:1.2.3-1.1
+  - libzbar-dev=0.23.92-7
   - make=4.3-4.1
   - mingetty=1.08-4
   - openbox=3.6.1-10


### PR DESCRIPTION
This is required for any package that dynamically links against `zbar`, which `zbar-rust` does.

See https://github.com/votingworks/vxsuite/issues/4078.