### PR TITLE
chore: add `libzbar-dev` package

### DIFF
--- a/playbooks/install-vxsuite-packages.yaml
+++ b/playbooks/install-vxsuite-packages.yaml
@@ -61,6 +61,7 @@
       - libgif-dev
       - libpcsclite1
       - libpcsclite-dev
+      - libzbar-dev
 
     app_mark_packages:
       - libpcsclite1

--- a/playbooks/install-vxsuite-packages.yaml
+++ b/playbooks/install-vxsuite-packages.yaml
@@ -77,6 +77,7 @@
       - libgif-dev
       - libpcsclite1
       - libpcsclite-dev
+      - libzbar-dev
 
   tasks:
     - name: Create a list of all the packages we need


### PR DESCRIPTION
We need `libzbar-dev` for https://github.com/votingworks/vxsuite/pull/4092. This may be unnecessary long term (see https://github.com/votingworks/vxsuite-build-system/pull/82), but for now it at least shouldn't hurt.