### PR TITLE
add to appropriate inventory package definitions

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -63,6 +63,7 @@ all_packages:
   - sane-utils
   - sbsigntool
   - swig
+  - systemd-boot-efi
   - tar
   - trash-cli
   - unclutter

--- a/inventories/sli_test/group_vars/all/packages.yaml
+++ b/inventories/sli_test/group_vars/all/packages.yaml
@@ -56,6 +56,7 @@ all_packages:
   - ruby=1:3.1
   - sbsigntool=0.9.4-3.1
   - swig=4.1.0-0.2
+  - systemd-boot-efi=252.17-1~deb12u1
   - tar=1.34+dfsg-1.2
   - trash-cli=0.17.1.14-5
   - unclutter=8-25

--- a/inventories/v3.1/group_vars/all/packages.yaml
+++ b/inventories/v3.1/group_vars/all/packages.yaml
@@ -63,6 +63,7 @@ all_packages:
   - sane-utils
   - sbsigntool
   - swig
+  - systemd-boot-efi
   - tar
   - trash-cli
   - unclutter


### PR DESCRIPTION
For Debian 12 secure boot, we need `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. This used to be included by default, but it is now part of a separate package. This ensures it will be installed during build. 