### PR TITLE
linux tools for signing kernel modules if needed

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -48,6 +48,7 @@ all_packages:
   - libxss1
   - libxtst6
   - libzbar-dev
+  - linux-kbuild-6.1
   - make
   - mingetty
   - openbox

--- a/inventories/sli_test/group_vars/all/packages.yaml
+++ b/inventories/sli_test/group_vars/all/packages.yaml
@@ -43,6 +43,7 @@ all_packages:
   - libxss1=1:1.2.3-1
   - libxtst6=2:1.2.3-1.1
   - libzbar-dev=0.23.92-7
+  - linux-kbuild-6.1=6.1.55-1
   - make=4.3-4.1
   - mingetty=1.08-4
   - openbox=3.6.1-10

--- a/inventories/v3.1/group_vars/all/packages.yaml
+++ b/inventories/v3.1/group_vars/all/packages.yaml
@@ -48,6 +48,7 @@ all_packages:
   - libxss1
   - libxtst6
   - libzbar-dev
+  - linux-kbuild-6.1
   - make
   - mingetty
   - openbox


### PR DESCRIPTION
If we need to sign kernel modules running under secure boot, we need tools found in linux-kbuild-6.1 (Debian 12 runs the 6.1 kernel)