### PR TITLE
Automate secure boot xml settings

### DIFF
--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -4,8 +4,9 @@ repos:
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-latest"
 vm_disk_size_gb: 110
-iso_name: "debian-12.2.0-amd64-netinst.iso"
-iso_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true

--- a/inventories/parallels-latest/group_vars/all/main.yaml
+++ b/inventories/parallels-latest/group_vars/all/main.yaml
@@ -1,11 +1,12 @@
 repos:
   vxsuite:
-    version: adam/trusted-build
+    version: main
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-12.2"
 vm_disk_size_gb: 110
-iso_name: "debian-12.2.0-amd64-netinst.iso"
-iso_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true

--- a/inventories/sli_test/group_vars/all/main.yaml
+++ b/inventories/sli_test/group_vars/all/main.yaml
@@ -4,8 +4,9 @@ repos:
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "sli-base"
 vm_disk_size_gb: 110
-iso_name: "debian-12.2.0-amd64-netinst.iso"
-iso_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true

--- a/inventories/v3.1/group_vars/all/main.yaml
+++ b/inventories/v3.1/group_vars/all/main.yaml
@@ -4,8 +4,9 @@ repos:
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian12base110"
 vm_disk_size_gb: 110
-iso_name: "debian-12.2.0-amd64-netinst.iso"
-iso_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true

--- a/inventories/vxdev-stable/group_vars/all/main.yaml
+++ b/inventories/vxdev-stable/group_vars/all/main.yaml
@@ -4,8 +4,9 @@ repos:
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "vxdev-base"
 vm_disk_size_gb: 110
-iso_name: "debian-12.2.0-amd64-netinst.iso"
-iso_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "vxdev-preseed.cfg"
 secure_boot: true

--- a/playbooks/virtmanager/create-base-vm.yaml
+++ b/playbooks/virtmanager/create-base-vm.yaml
@@ -2,6 +2,9 @@
   hosts: localhost
   become: yes
 
+  vars:
+    current_url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
+
   tasks:
 
     - name: Allocate 60% of system RAM for the VM
@@ -12,10 +15,18 @@
       set_fact:
         vm_cpus: "{{ (ansible_facts['processor_nproc'] * 0.80)|round(0, 'floor')|int }}"
 
-    - name: Download Debian ISO
+    - name: Download Debian ISO from current url
+      get_url: 
+        url: "{{ current_url }}/{{ iso_name }}"
+        dest: "{{ virt_image_path }}/{{ iso_name }}"
+      register: current_download
+      ignore_errors: true
+
+    - name: Download Debian ISO from archive url if current was not available
       get_url: 
         url: "{{ iso_url }}/{{ iso_name }}"
         dest: "{{ virt_image_path }}/{{ iso_name }}"
+      when: current_download.status_code == 404 
 
     - name: See if virt networking is active
       shell: 
@@ -77,3 +88,21 @@
       register: output
       when: does_vm_exist.rc != 0
 
+    - name: Remove the cdrom definition
+      ansible.builtin.command:
+        cmd: sed -i "/<disk type='file' device='cdrom'>/,/<\/disk>/ d" /etc/libvirt/qemu/{{ vm_name }}.xml 
+
+    - name: Check if scsi device already exists
+      ansible.builtin.command:
+        cmd: grep "<controller type='scsi' index='0' model='virtio-scsi'>" /etc/libvirt/qemu/{{ vm_name }}.xml
+      register: scsi_exists
+      ignore_errors: true
+
+    - name: Add scsi device
+      ansible.builtin.command:
+        cmd: sed -i "/<\/disk>/ a <controller type='scsi' index='0' model='virtio-scsi'>\n  <address type='pci' domain='0x0000' bus='0x07' slot='0x00' function='0x0'\/>\n<\/controller>" /etc/libvirt/qemu/{{ vm_name }}.xml
+      when: scsi_exists.rc != 0
+
+    - name: Update the {{ vm_name }} VM with device changes
+      ansible.builtin.command:
+        cmd: "virsh define /etc/libvirt/qemu/{{ vm_name }}.xml"


### PR DESCRIPTION
This PR automates editing the XML definition for a base VM so secure boot keys can be mounted as an internal device (sda). It also ensures older versions of debian base images can be downloaded once they are no longer the current version. 