### PR TITLE
Use apt preferences to manage dependency version mismatches

### DIFF
--- a/inventories/v3.1/group_vars/all/main.yaml
+++ b/inventories/v3.1/group_vars/all/main.yaml
@@ -12,4 +12,5 @@ vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 rust_version: "1.72.0"
 cloned_images:
-  - vx-20231218
+  - vx-v3.1-online
+  - vx-v3.1-offline

--- a/inventories/v3.1/group_vars/all/main.yaml
+++ b/inventories/v3.1/group_vars/all/main.yaml
@@ -12,5 +12,5 @@ vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 rust_version: "1.72.0"
 cloned_images:
-  - vx-v3.1-online
-  - vx-v3.1-offline
+  - online
+  - offline

--- a/inventories/v3.1/group_vars/all/main.yaml
+++ b/inventories/v3.1/group_vars/all/main.yaml
@@ -12,4 +12,4 @@ vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 rust_version: "1.72.0"
 cloned_images:
-  - vx
+  - vx-20231218

--- a/inventories/v3.1/group_vars/all/packages.yaml
+++ b/inventories/v3.1/group_vars/all/packages.yaml
@@ -1,7 +1,11 @@
 ---
 batch_package_install: false
-apt_snapshot_date: "20231218"
+apt_snapshot_date: "20231219"
 release_name: "bookworm"
+
+create_apt_preference_config:
+  - curl
+  - libcurl4
 
 all_packages:
   - alsa-utils=1.2.8-1
@@ -30,6 +34,7 @@ all_packages:
   - kde-cli-tools=4:5.27.5.1-2
   - libatspi2.0-0=2.46.0-5
   - libcairo2-dev=1.16.0-7
+  - libcurl4=7.88.1-10+deb12u4
   - libgif-dev=5.2.1-2.5
   - libglib2.0-bin=2.74.6-2
   - libgtk-3-0=3.24.38-2~deb12u1

--- a/roles/apt/tasks/main.yaml
+++ b/roles/apt/tasks/main.yaml
@@ -1,5 +1,11 @@
 ---
 
+- name: Create apt preference config (if necessary)
+  ansible.builtin.template:
+    src: ./snapshot_preference.j2
+    dest: /etc/apt/preferences.d/snapshot_preference_config
+  when: create_apt_preference_config is defined
+
 - import_tasks: download_only.yaml
   tags:
     - online

--- a/roles/apt/tasks/snapshot_preference.j2
+++ b/roles/apt/tasks/snapshot_preference.j2
@@ -1,0 +1,6 @@
+{% for package in create_apt_preference_config %}
+Package: {{ package }}
+Pin: origin "snapshot.debian.org"
+Pin-Priority: 1001
+
+{% endfor %}


### PR DESCRIPTION
In some cases, it's possible for apt to update a package but leave the older version available in the latest main + security repo. When package dependencies are also updated in this manner, the dependency versions can result in a mismatch that will not allow the package to be installed. 

This PR provides a mechanism to use apt preferences to specify the repo for packages experiencing this issue. When this dependency mismatch occurs, we ensure the affected packages use the snapshot repository, even if they may also be available in the latest main still. In most cases, this problem will resolve itself once the older packages are removed, but this provides a solution in the case a build fails with this issue. 