### PR TITLE
Playbook to generate SLI COTS report

### DIFF
--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -10,6 +10,74 @@
       set_fact:
         cots_csv_file: "/tmp/cots_report.csv"
 
+    # Rust version and checksum
+    #
+    - name: Determine system architecture for appropriate Rust install
+      set_fact: 
+        architecture: "{{ 'aarch64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x86_64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
+
+    - name: Define Rust tarball name
+      set_fact: 
+        rust_tarball: "rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+
+    - name: Define the URL to download the appropriate Rust tarball
+      set_fact:
+        rust_tarball_url: "https://static.rust-lang.org/dist/{{ rust_tarball }}"
+
+    - name: Define Rust manifest name
+      set_fact: 
+        rust_manifest: "channel-rust-{{ rust_version }}.toml"
+
+    - name: Define URL to Rust channel manifest for this version
+      set_fact:
+        rust_manifest_url: "https://static.rust-lang.org/dist/{{ rust_manifest }}"
+
+    - name: Download Rust channel manifest for this version
+      ansible.builtin.get_url:
+        url: "{{ rust_manifest_url }}"
+        dest: "/tmp/{{ rust_manifest }}"
+
+    - name: Find the sha256 hash for our version
+      ansible.builtin.shell:
+        cmd: "grep -A1 {{ rust_tarball }} /tmp/{{ rust_manifest }} | grep hash | cut -d'=' -f2 | xargs"
+      register: rust_checksum_from_manifest
+
+    - name: Add Rust to COTS report
+      ansible.builtin.shell:
+        cmd: >
+          echo "{{ rust_tarball_url }},{{ rust_tarball }},{{ rust_version }},DATE,{{ rust_checksum_from_manifest.stdout }}" >> {{ cots_csv_file }}
+
+    # Node version and checksum
+    #
+    - name: Set the Node filename
+      set_fact:
+        node_tarball: "node-v{{ node_version }}-linux-{{ architecture }}.tar.gz"
+
+    - name: Set Node release URL
+      set_fact:
+        node_release_url: "https://nodejs.org/dist/v{{ node_version }}/{{ node_tarball }}"
+
+    - name: Define the Node {{ node_version }} checksum file path
+      set_fact:
+        node_checksums_file: "/tmp/node-{{ node_version }}.checksums"
+
+    - name: Download the Node {{ node_version }} SHA256 reference
+      ansible.builtin.get_url:
+        url: "https://nodejs.org/dist/v{{ node_version }}/SHASUMS256.txt"
+        dest: "{{ node_checksums_file }}" 
+
+    - name: Find the appropriate checksum for Node {{ node_version }}
+      ansible.builtin.shell:
+        cmd: "grep node-v{{ node_version }}-linux-{{ architecture }}.tar.gz {{ node_checksums_file }} | cut -d' ' -f1"
+      register: node_checksum
+
+    - name: Add Node to COTS report
+      ansible.builtin.shell:
+        cmd: >
+          echo "{{ node_release_url }},{{ node_tarball }},{{ node_version }},DATE,{{ node_checksum.stdout }}" >> {{ cots_csv_file }}
+
+    # Apt packages versions and checksums
+    #
     - name: Set the apt repo URL
       ansible.builtin.uri:
         url: "https://snapshot.debian.org/archive/debian/{{ apt_snapshot_date }}"
@@ -47,37 +115,3 @@
           echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}" >> {{ cots_csv_file }}
       loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
 
-    - name: Determine system architecture for appropriate Rust install
-      set_fact: 
-        architecture: "{{ 'aarch64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x86_64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
-
-    - name: Define Rust tarball name
-      set_fact: 
-        rust_tarball: "rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
-
-    - name: Define the URL to download the appropriate Rust tarball
-      set_fact:
-        rust_tarball_url: "https://static.rust-lang.org/dist/{{ rust_tarball }}"
-
-    - name: Define Rust manifest name
-      set_fact: 
-        rust_manifest: "channel-rust-{{ rust_version }}.toml"
-
-    - name: Define URL to Rust channel manifest for this version
-      set_fact:
-        rust_manifest_url: "https://static.rust-lang.org/dist/{{ rust_manifest }}"
-
-    - name: Download Rust channel manifest for this version
-      ansible.builtin.get_url:
-        url: "{{ rust_manifest_url }}"
-        dest: "/tmp/{{ rust_manifest }}"
-
-    - name: Find the sha256 hash for our version
-      ansible.builtin.shell:
-        cmd: "grep -A1 {{ rust_tarball }} /tmp/{{ rust_manifest }} | grep hash | cut -d'=' -f2 | xargs"
-      register: rust_checksum_from_manifest
-
-    - name: Add Rust to COTS report
-      ansible.builtin.shell:
-        cmd: >
-          echo "{{ rust_tarball_url }},{{ rust_tarball }},{{ rust_version }},DATE,{{ rust_checksum_from_manifest.stdout }}" >> {{ cots_csv_file }}

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -50,7 +50,7 @@
     - name: Add Rust to COTS report
       ansible.builtin.shell:
         cmd: >
-          echo "{{ rust_tarball_url }},{{ rust_tarball }},{{ rust_version }},DATE,{{ rust_checksum_from_manifest.stdout }}" >> {{ cots_csv_file }}
+          echo "{{ rust_tarball_url }},{{ rust_tarball }},{{ rust_version }},,{{ rust_checksum_from_manifest.stdout }}" >> {{ cots_csv_file }}
 
     # Node version and checksum
     #
@@ -83,7 +83,7 @@
     - name: Add Node to COTS report
       ansible.builtin.shell:
         cmd: >
-          echo "{{ node_release_url }},{{ node_tarball }},{{ node_version }},DATE,{{ node_checksum.stdout }}" >> {{ cots_csv_file }}
+          echo "{{ node_release_url }},{{ node_tarball }},{{ node_version }},,{{ node_checksum.stdout }}" >> {{ cots_csv_file }}
 
     # Apt packages versions and checksums
     #
@@ -121,6 +121,6 @@
     - name: Print COTS for apt packages
       ansible.builtin.shell:
         cmd: >
-          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}" >> {{ cots_csv_file }}
+          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},,{{ item.2.stdout }}" >> {{ cots_csv_file }}
       loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -6,6 +6,13 @@
   become: true
 
   tasks:
+    - name: Set the apt repo URL
+      ansible.builtin.uri:
+        url: "https://snapshot.debian.org/archive/debian/{{ apt_snapshot_date }}"
+        return_content: no
+        follow_redirects: all
+      register: apt_url
+
     - name: De-dupe the list for efficiency
       set_fact:
         all_packages: "{{ all_packages | unique | select | list }}"
@@ -30,8 +37,8 @@
       loop: "{{ all_packages + tpm_packages }}"
       register: apt_checksums
 
-    - name: Print files and checksums
+    - name: Print COTS for apt packages
       debug:
-        msg: "{{ item.0.stdout }} = {{ item.1.stdout }}"
+        msg: "{{ apt_url.url }}{{ item.0.stdout }},{{ item.0.stdout }},{{ item.0.stdout | split('=') | last }},DATE,{{ item.1.stdout }}"
       loop: "{{ apt_filenames.results | zip(apt_checksums.results) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -19,7 +19,7 @@
         cmd: >
           apt-cache show {{ item }} | grep "Filename" | 
           cut -d' ' -f2
-      loop: "{{ all_packages | zip(tpm_packages) | list}}"
+      loop: "{{ all_packages + tpm_packages }}"
       register: apt_filenames
 
     - name: Get the SHA256 hash
@@ -27,7 +27,7 @@
         cmd: >
           apt-cache show {{ item }} | grep "SHA256" | 
           cut -d' ' -f2
-      loop: "{{ all_packages | zip(tpm_packages) | list}}"
+      loop: "{{ all_packages + tpm_packages }}"
       register: apt_checksums
 
     - name: Print files and checksums

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -19,9 +19,7 @@
         cmd: >
           apt-cache show {{ item }} | grep "Filename" | 
           cut -d' ' -f2
-      loop: 
-        - "{{ all_packages }}"
-        - "{{ tpm_packages }}"
+      loop: "{{ all_packages }}"
       register: apt_filenames
 
     - name: Print to tmp file

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -14,12 +14,12 @@
       register: apt_url
 
     - name: Create the combined list
-        set_fact:
-          combined_packages: "{{ all_packages + tpm_packages }}"
+      set_fact:
+        combined_packages: "{{ all_packages + tpm_packages }}"
 
     - name: Dedupe the list
-        set_fact:
-          deduped_packages: "{{ combined_packages | unique | select | list }}"
+      set_fact:
+        deduped_packages: "{{ combined_packages | unique | select | list }}"
 
     - name: Get the filename in the apt repo
       ansible.builtin.shell:

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -32,6 +32,6 @@
 
     - name: Print files and checksums
       debug:
-        msg: "{{ item.0 }} = {{ item.1 }}"
-      loop: "{{ apt_filenames | zip(apt_checksums) | list }}"
+        msg: "{{ item.0.stdout }} = {{ item.1.stdout }}"
+      loop: "{{ apt_filenames.results | zip(apt_checksums.results) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -1,0 +1,31 @@
+---
+
+- name: Generate a report of COTS tools used for this build
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+    - name: De-dupe the list for efficiency
+      set_fact:
+        all_packages: "{{ all_packages | unique | select | list }}"
+
+    - name: De-dupe the TPM list for efficiency
+      set_fact:
+        tpm_packages: "{{ tpm_packages | unique | select | list }}"
+
+    - name: Get the filename in the apt repo
+      ansible.builtin.shell:
+        cmd: >
+          apt-cache show {{ item }} | grep "Filename" | 
+          cut -d' ' -f2
+      loop: 
+        - "{{ all_packages }}"
+        - "{{ tpm_packages }}"
+      register: apt_filenames
+
+    - name: Print to tmp file
+      ansible.builtin.shell:
+        cmd: 'echo "  - {{ item.stdout | quote }}" >> /tmp/apt_filenames'
+      loop: "{{ apt_filenames.results }}"
+

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -10,6 +10,11 @@
       set_fact:
         cots_csv_file: "/tmp/cots_report.csv"
 
+    - name: Delete the file if it already exists
+      ansible.builtin.file:
+        path: "{{ cots_csv_file }}"
+        state: absent
+
     # Rust version and checksum
     #
     - name: Determine system architecture for appropriate Rust install

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -13,20 +13,16 @@
         follow_redirects: all
       register: apt_url
 
-    - name: De-dupe the list for efficiency
-      set_fact:
-        all_packages: "{{ all_packages | unique | select | list }}"
-
-    - name: De-dupe the TPM list for efficiency
-      set_fact:
-        tpm_packages: "{{ tpm_packages | unique | select | list }}"
+    - name: Create the combined list
+        set_fact:
+          deduped_packages: "{{ all_packages + tpm_packages | unique | select | list }}"
 
     - name: Get the filename in the apt repo
       ansible.builtin.shell:
         cmd: >
           apt-cache show {{ item }} | grep "Filename" | 
           cut -d' ' -f2
-      loop: "{{ all_packages + tpm_packages }}"
+      loop: "{{ deduped_packages }}"
       register: apt_filenames
 
     - name: Get the SHA256 hash
@@ -34,11 +30,11 @@
         cmd: >
           apt-cache show {{ item }} | grep "SHA256" | 
           cut -d' ' -f2
-      loop: "{{ all_packages + tpm_packages }}"
+      loop: "{{ deduped_packages }}"
       register: apt_checksums
 
     - name: Print COTS for apt packages
       debug:
-        msg: "{{ apt_url.url }}{{ item.0.stdout }},{{ item.0.stdout }},{{ item.0.stdout | split('=') | last }},DATE,{{ item.1.stdout }}"
-      loop: "{{ apt_filenames.results | zip(apt_checksums.results) | list }}"
+        msg: "{{ apt_url.url }}{{ item.1.stdout }},{{ item.0 }},{{ item.0.stdout | split('=') | last }},DATE,{{ item.2.stdout }}"
+      loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -38,7 +38,7 @@
       register: apt_checksums
 
     - name: Print COTS for apt packages
-      debug:
-        msg: "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}"
+      ansible.builtin.shell:
+        cmd: 'echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}" >> /tmp/cots_report.csv'
       loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -6,6 +6,10 @@
   become: true
 
   tasks:
+    - name: Set the csv filename
+      set_fact:
+        cots_csv_file: "/tmp/cots_report.csv"
+
     - name: Set the apt repo URL
       ansible.builtin.uri:
         url: "https://snapshot.debian.org/archive/debian/{{ apt_snapshot_date }}"
@@ -40,6 +44,40 @@
     - name: Print COTS for apt packages
       ansible.builtin.shell:
         cmd: >
-          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}" >> /tmp/cots_report.csv
+          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}" >> {{ cots_csv_file }}
       loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
 
+    - name: Determine system architecture for appropriate Rust install
+      set_fact: 
+        architecture: "{{ 'aarch64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x86_64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
+
+    - name: Define Rust tarball name
+      set_fact: 
+        rust_tarball: "rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+
+    - name: Define the URL to download the appropriate Rust tarball
+      set_fact:
+        rust_tarball_url: "https://static.rust-lang.org/dist/{{ rust_tarball }}"
+
+    - name: Define Rust manifest name
+      set_fact: 
+        rust_manifest: "channel-rust-{{ rust_version }}.toml"
+
+    - name: Define URL to Rust channel manifest for this version
+      set_fact:
+        rust_manifest_url: "https://static.rust-lang.org/dist/{{ rust_manifest }}"
+
+    - name: Download Rust channel manifest for this version
+      ansible.builtin.get_url:
+        url: "{{ rust_manifest_url }}"
+        dest: "/tmp/{{ rust_manifest }}"
+
+    - name: Find the sha256 hash for our version
+      ansible.builtin.shell:
+        cmd: "grep -A1 {{ rust_tarball }} /tmp/{{ rust_manifest }} | grep hash | cut -d'=' -f2 | xargs"
+      register: rust_checksum_from_manifest
+
+    - name: Add Rust to COTS report
+      ansible.builtin.shell:
+        cmd: >
+          echo "{{ rust_tarball_url }},{{ rust_tarball }},{{ rust_version }},DATE,{{ rust_checksum_from_manifest.stdout }}" >> {{ cots_csv_file }}

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -15,7 +15,11 @@
 
     - name: Create the combined list
         set_fact:
-          deduped_packages: "{{ all_packages + tpm_packages | unique | select | list }}"
+          combined_packages: "{{ all_packages + tpm_packages }}"
+
+    - name: Dedupe the list
+        set_fact:
+          deduped_packages: "{{ combined_packages | unique | select | list }}"
 
     - name: Get the filename in the apt repo
       ansible.builtin.shell:

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -14,11 +14,11 @@
     #
     - name: Determine system architecture for appropriate Rust install
       set_fact: 
-        architecture: "{{ 'aarch64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x86_64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
+        rust_architecture: "{{ 'aarch64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x86_64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
 
     - name: Define Rust tarball name
       set_fact: 
-        rust_tarball: "rust-{{ rust_version }}-{{ architecture }}-unknown-linux-gnu.tar.gz"
+        rust_tarball: "rust-{{ rust_version }}-{{ rust_architecture }}-unknown-linux-gnu.tar.gz"
 
     - name: Define the URL to download the appropriate Rust tarball
       set_fact:
@@ -49,9 +49,13 @@
 
     # Node version and checksum
     #
+    - name: Determine system architecture for Node
+      set_fact:
+        node_architecture: "{{ 'arm64' if (ansible_architecture == 'aarch64' or ansible_architecture == 'arm64') else 'x64' if (ansible_architecture == 'x86_64') else 'unsupported' }}"
+
     - name: Set the Node filename
       set_fact:
-        node_tarball: "node-v{{ node_version }}-linux-{{ architecture }}.tar.gz"
+        node_tarball: "node-v{{ node_version }}-linux-{{ node_architecture }}.tar.gz"
 
     - name: Set Node release URL
       set_fact:
@@ -68,7 +72,7 @@
 
     - name: Find the appropriate checksum for Node {{ node_version }}
       ansible.builtin.shell:
-        cmd: "grep node-v{{ node_version }}-linux-{{ architecture }}.tar.gz {{ node_checksums_file }} | cut -d' ' -f1"
+        cmd: "grep node-v{{ node_version }}-linux-{{ node_architecture }}.tar.gz {{ node_checksums_file }} | cut -d' ' -f1"
       register: node_checksum
 
     - name: Add Node to COTS report

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -39,6 +39,6 @@
 
     - name: Print COTS for apt packages
       debug:
-        msg: "{{ apt_url.url }}{{ item.1.stdout }},{{ item.0 }},{{ item.0.stdout | split('=') | last }},DATE,{{ item.2.stdout }}"
+        msg: "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}"
       loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -19,11 +19,19 @@
         cmd: >
           apt-cache show {{ item }} | grep "Filename" | 
           cut -d' ' -f2
-      loop: "{{ all_packages }}"
+      loop: "{{ all_packages | zip(tpm_packages) | list}}"
       register: apt_filenames
 
-    - name: Print to tmp file
+    - name: Get the SHA256 hash
       ansible.builtin.shell:
-        cmd: 'echo "  - {{ item.stdout | quote }}" >> /tmp/apt_filenames'
-      loop: "{{ apt_filenames.results }}"
+        cmd: >
+          apt-cache show {{ item }} | grep "SHA256" | 
+          cut -d' ' -f2
+      loop: "{{ all_packages | zip(tpm_packages) | list}}"
+      register: apt_checksums
+
+    - name: Print files and checksums
+      debug:
+        msg: "{{ item.0 }} = {{ item.1 }}"
+      loop: "{{ apt_filenames | zip(apt_checksums) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -39,6 +39,7 @@
 
     - name: Print COTS for apt packages
       ansible.builtin.shell:
-        cmd: 'echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}" >> /tmp/cots_report.csv'
+        cmd: >
+          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},DATE,{{ item.2.stdout }}" >> /tmp/cots_report.csv
       loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
 


### PR DESCRIPTION
As part of SLI testing, we are required to provide a report of COTS tools for them to validate checksums against. This playbook generates that report.

Quick summary of how each tool/package checksum is determined:

Rust: the Rust manifest is downloaded, and the version being installed by the build is looked up to obtain the checksum.
Node: the Node checksum file for the version being used is downloaded, and the checksum is then looked up.
Apt: apt-cache show <pkg> is used to determine the filename used in the snapshot repository, along with the checksum value for the package.

To independently confirm the checksums, you can use curl to download the file and run a sha256sum tool of your choice against the downloaded file. 