### PR TITLE
misc doc updates for deb12

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 1. Parallels Pro for Mac: https://www.parallels.com/products/desktop/pro/
 2. Parallels Virtualization SDK for Mac: https://www.parallels.com/products/desktop/download/
 3. Xcode Command Line Tools (There are multiple ways to install this. A simple method: `xcode-select --install`
-4. After these are installed, run: `sudo ln -s /Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/prlsdkapi.pth /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/prlsdkapi.pth`
-    1. NOTE: This is due to a known issue in Parallels and may not be necessary in the future. 
-5. Install `packer` via homebrew (if you don't already have homebrew installed, you can install homebrew via instructions here: https://brew.sh/):
+4. Install `packer` via homebrew (if you don't already have homebrew installed, you can install homebrew via instructions here: https://brew.sh/):
     1. `brew tap hashicorp/tap`
     2. `brew install hashicorp/tap/packer`
     3. (Optional, but recommended): `brew upgrade hashicorp/tap/packer`
@@ -19,11 +17,11 @@
     2. Via ssh: `git clone git@github.com:votingworks/vxsuite-build-system.git`
 2. Initialize packer
     1. Be sure to cd into the newly cloned `vxsuite-build-system` repo
-    2. Run: `packer init parallels-debian11.pkr.hcl`
+    2. Run: `packer init parallels-debian12.pkr.hcl`
 
 ## Build a base Debian VM with VotingWorks repositories cloned
 
-1. Run: `packer build parallels-debian11.pkr.hcl` (This will take 10-20 minutes, depending on your machine and internet speed. You can watch the progress by opening the VM from the Parallels Control Center.)
+1. Run: `packer build parallels-debian12.pkr.hcl` (This will take 10-20 minutes, depending on your machine and internet speed. You can watch the progress by opening the VM from the Parallels Control Center.)
 2. Once it completes, you will have a new VM available in your local Parallels directory. This is `~/Parallels` by default. To start this VM, run: `open ~/Parallels/debian-11.6-arm64.pvm/`
 3. The default username is `vx` with a default password of `changeme`
 
@@ -35,7 +33,7 @@ You can further customize your Parallels VM with various options provided to the
 
 If you'd like to change the default username, use the `local_user` variable.
 
-For example: `packer build -var "local_user=your_username" parallels-debian11.pkr.hcl`
+For example: `packer build -var "local_user=your_username" parallels-debian12.pkr.hcl`
 
 ### Share a folder from your Mac to the Parallels VM
 
@@ -44,7 +42,7 @@ It's possible to make a local folder accessible to this Parallels VM via two var
 - `enable_shared_path` - whether to enable/disable sharing. The default is `disable`
 
 For example, to share your home directory to the VM:
-`packer build -var "shared_path=/Users/your_username" -var "enable_shared_path=enable" parallels-debian11.pkr.hcl`
+`packer build -var "shared_path=/Users/your_username" -var "enable_shared_path=enable" parallels-debian12.pkr.hcl`
 
 ### Define CPU and Memory (RAM) resources allocated to the VM:
 
@@ -54,11 +52,11 @@ Depending on your needs, you can increase or decrease the resources allocated to
 - `vm_memory` - This determines the amount of RAM (in megabytes) available to the VM. The default is 8192 (8GB).
 
 For example, to allocate 4 CPUs and 16 GB of RAM to a VM:
-`packer build -var "vm_cpus=4" -var "vm_memory=16384" parallels-debian11.pkr.hcl`
+`packer build -var "vm_cpus=4" -var "vm_memory=16384" parallels-debian12.pkr.hcl`
 
 ### Rename your VM
 
 To change the name of the VM being built, use the `vm_name` variable (default is debian-11.6-arm64.pvm)
 
 For example, to name your VM "MyVM":
-`packer build -var "vm_name=MyVM" parallels-debian11.pkr.hcl`
+`packer build -var "vm_name=MyVM" parallels-debian12.pkr.hcl`

--- a/inventories/parallels-latest/group_vars/all/packages.yaml
+++ b/inventories/parallels-latest/group_vars/all/packages.yaml
@@ -5,6 +5,7 @@ all_packages:
   - alsa-utils
   - brightnessctl
   - build-essential
+  - chromium
   - cryptsetup
   - cups
   - cups-bsd


### PR DESCRIPTION
Minor documentation updates to move to debian 12 as our default OS. Also includes `chromium` in the parallels build.