### PR TITLE
Initial system level build tooling for new CACvote apps

### DIFF
--- a/inventories/cacvote-latest/group_vars/all/brother.yaml
+++ b/inventories/cacvote-latest/group_vars/all/brother.yaml
@@ -8,9 +8,12 @@ brother_drivers:
   PJ-822:
     url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"
     checksum: "c1fae128905bc0dbe91080fd08adc62cb2e4f7b959291d91e8294cd3f91dadf3"
+    delete_via_lpadmin: false
   PJ-823:
     url: "https://download.brother.com/welcome/dlfp100952/pj823pdrv-1.2.0-1.i386.deb"
     checksum: "933b99e2963f5642f84474a288b1e867384bda0b0440ec36a8d22e05e8478546"
+    delete_via_lpadmin: false
   QL-1100:
     url: "https://download.brother.com/welcome/dlfp100573/ql1100pdrv-2.1.4-0.i386.deb"
     checksum: "4de864edec5c3d5bbcbc47c77d3fc90bae3b19b72a409d04f178e89437cfe2f3"
+    delete_via_lpadmin: false

--- a/inventories/cacvote-latest/group_vars/all/brother.yaml
+++ b/inventories/cacvote-latest/group_vars/all/brother.yaml
@@ -1,4 +1,6 @@
 ---
+delete_via_lpadmin: false
+
 brother_32bit_packages:
   - libc6:i386
   - libncurses5:i386
@@ -8,12 +10,9 @@ brother_drivers:
   PJ-822:
     url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"
     checksum: "c1fae128905bc0dbe91080fd08adc62cb2e4f7b959291d91e8294cd3f91dadf3"
-    delete_via_lpadmin: false
   PJ-823:
     url: "https://download.brother.com/welcome/dlfp100952/pj823pdrv-1.2.0-1.i386.deb"
     checksum: "933b99e2963f5642f84474a288b1e867384bda0b0440ec36a8d22e05e8478546"
-    delete_via_lpadmin: false
   QL-1100:
     url: "https://download.brother.com/welcome/dlfp100573/ql1100pdrv-2.1.4-0.i386.deb"
     checksum: "4de864edec5c3d5bbcbc47c77d3fc90bae3b19b72a409d04f178e89437cfe2f3"
-    delete_via_lpadmin: false

--- a/inventories/cacvote-latest/group_vars/all/brother.yaml
+++ b/inventories/cacvote-latest/group_vars/all/brother.yaml
@@ -1,0 +1,16 @@
+---
+brother_32bit_packages:
+  - libc6:i386
+  - libncurses5:i386
+  - libstdc++6:i386
+
+brother_drivers:
+  PJ-822:
+    url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"
+    checksum: "c1fae128905bc0dbe91080fd08adc62cb2e4f7b959291d91e8294cd3f91dadf3"
+  PJ-823:
+    url: "https://download.brother.com/welcome/dlfp100952/pj823pdrv-1.2.0-1.i386.deb"
+    checksum: "933b99e2963f5642f84474a288b1e867384bda0b0440ec36a8d22e05e8478546"
+  QL-1100:
+    url: "https://download.brother.com/welcome/dlfp100573/ql1100pdrv-2.1.4-0.i386.deb"
+    checksum: "4de864edec5c3d5bbcbc47c77d3fc90bae3b19b72a409d04f178e89437cfe2f3"

--- a/inventories/cacvote-latest/group_vars/all/idprt.yaml
+++ b/inventories/cacvote-latest/group_vars/all/idprt.yaml
@@ -1,4 +1,5 @@
 ---
 idprt_drivers:
   ID-PRT:
-    url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"
+    url: "https://www.idprt.com/prt_v2/files/down_file/id/131/fid/432.html"
+

--- a/inventories/cacvote-latest/group_vars/all/idprt.yaml
+++ b/inventories/cacvote-latest/group_vars/all/idprt.yaml
@@ -1,0 +1,4 @@
+---
+idprt_drivers:
+  ID-PRT:
+    url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"

--- a/inventories/cacvote-latest/group_vars/all/main.yaml
+++ b/inventories/cacvote-latest/group_vars/all/main.yaml
@@ -1,0 +1,16 @@
+repos:
+  kiosk-browser:
+    version: main
+  cacvote:
+    version: main
+virt_image_path: "/var/lib/libvirt/images"
+vm_name: "debian12-2-cacvote-base"
+vm_disk_size_gb: 110
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
+vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
+vm_preseed_file: "cacvote-prod-preseed.cfg"
+secure_boot: true
+cloned_images:
+  - cacvote

--- a/inventories/cacvote-latest/group_vars/all/node.yaml
+++ b/inventories/cacvote-latest/group_vars/all/node.yaml
@@ -1,0 +1,8 @@
+node_version: "16.19.1"
+npm_packages:
+  yarn:
+    version: "1.22.15"
+    checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
+  pnpm:
+    version: "8.1.0"
+    checksum: "09ebf306075e96037432071992bb00340c263d85"

--- a/inventories/cacvote-latest/group_vars/all/packages.yaml
+++ b/inventories/cacvote-latest/group_vars/all/packages.yaml
@@ -18,3 +18,4 @@ all_packages:
   - libssl-dev
   - libx11-dev
   - pcscd
+  - ruby

--- a/inventories/cacvote-latest/group_vars/all/packages.yaml
+++ b/inventories/cacvote-latest/group_vars/all/packages.yaml
@@ -5,9 +5,11 @@ all_packages:
   - build-essential
   - chromium 
   - cups-bsd
+  - cups-filters
   - curl
   - git
   - libcairo2-dev
+  - libcupsimage2
   - libgif-dev 
   - libjpeg-dev
   - libpango1.0-dev
@@ -16,6 +18,8 @@ all_packages:
   - libpng-dev
   - libsane
   - libssl-dev
+  - libudev-dev
   - libx11-dev
   - pcscd
+  - postgresql
   - ruby

--- a/inventories/cacvote-latest/group_vars/all/packages.yaml
+++ b/inventories/cacvote-latest/group_vars/all/packages.yaml
@@ -1,0 +1,20 @@
+---
+batch_package_install: true
+
+all_packages:
+  - build-essential
+  - chromium 
+  - cups-bsd
+  - curl
+  - git
+  - libcairo2-dev
+  - libgif-dev 
+  - libjpeg-dev
+  - libpango1.0-dev
+  - libpcsclite-dev
+  - libpixman-1-dev
+  - libpng-dev
+  - libsane
+  - libssl-dev
+  - libx11-dev
+  - pcscd

--- a/inventories/cacvote-latest/group_vars/all/rubygems.yaml
+++ b/inventories/cacvote-latest/group_vars/all/rubygems.yaml
@@ -1,0 +1,4 @@
+gems:
+  fpm:
+    version: "1.15.1"
+    checksum: "1ffbf342a89ca97fb5c02e66946c97e2bd5413810f7f440ddf32f00a16052dbf"

--- a/inventories/cacvote-latest/group_vars/all/rust.yaml
+++ b/inventories/cacvote-latest/group_vars/all/rust.yaml
@@ -1,0 +1,3 @@
+rust_version: "1.72.0"
+targets_to_add:
+  - wasm32-unknown-unknown

--- a/inventories/cacvote-latest/hosts
+++ b/inventories/cacvote-latest/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/playbooks/trusted_build/brother_printers.yaml
+++ b/playbooks/trusted_build/brother_printers.yaml
@@ -66,19 +66,25 @@
       tags:
         - offline
 
-    - name: Get lpstat info for brother printers
-      ansible.builtin.shell:
-        cmd: "lpstat -p {{ item.key }}"
-      with_dict:
-        - "{{ brother_drivers }}"
-      register: lpstat_info
-      ignore_errors: yes
-      tags:
-        - offline
+    - name: Remove printer configs if needed
+      block:
 
-    - name: Remove printer configs that interfere with our config
-      ansible.builtin.command: "lpadmin -x {{ item.item.key }}"
-      when: item.rc == 0
-      loop: "{{ lpstat_info.results }}"
+        - name: Get lpstat info for brother printers
+          ansible.builtin.shell:
+            cmd: "lpstat -p {{ item.key }}"
+          with_dict:
+            - "{{ brother_drivers }}"
+          register: lpstat_info
+          ignore_errors: yes
+          tags:
+            - offline
+
+        - name: Remove printer configs that interfere with our config
+          ansible.builtin.command: "lpadmin -x {{ item.item.key }}"
+          when: item.rc == 0
+          loop: "{{ lpstat_info.results }}"
+          tags:
+            - offline
+      when: delete_via_lpadmin is undefined or delete_via_lpadmin is true
       tags:
         - offline

--- a/playbooks/trusted_build/brother_printers.yaml
+++ b/playbooks/trusted_build/brother_printers.yaml
@@ -66,25 +66,27 @@
       tags:
         - offline
 
-    - name: Remove printer configs if needed
-      block:
+    # By default, we delete cups printer configs
+    # but not in cacvote, so we added a delete_via_lpadmin config var
+    - block:
 
-        - name: Get lpstat info for brother printers
-          ansible.builtin.shell:
-            cmd: "lpstat -p {{ item.key }}"
-          with_dict:
-            - "{{ brother_drivers }}"
-          register: lpstat_info
-          ignore_errors: yes
-          tags:
-            - offline
+      - name: Get lpstat info for brother printers
+        ansible.builtin.shell:
+          cmd: "lpstat -p {{ item.key }}"
+        with_dict:
+          - "{{ brother_drivers }}"
+        register: lpstat_info
+        ignore_errors: yes
+        tags:
+          - offline
 
-        - name: Remove printer configs that interfere with our config
-          ansible.builtin.command: "lpadmin -x {{ item.item.key }}"
-          when: item.rc == 0
-          loop: "{{ lpstat_info.results }}"
-          tags:
-            - offline
-      when: delete_via_lpadmin is undefined or delete_via_lpadmin is true
+      - name: Remove printer configs that interfere with our config
+        ansible.builtin.command: "lpadmin -x {{ item.item.key }}"
+        when: item.rc == 0
+        loop: "{{ lpstat_info.results }}"
+        tags:
+          - offline
+
+      when: delete_via_lpadmin is not defined or delete_via_lpadmin is true
       tags:
         - offline

--- a/playbooks/trusted_build/cacvote_build.yaml
+++ b/playbooks/trusted_build/cacvote_build.yaml
@@ -1,0 +1,14 @@
+---
+- name: All the trusted build steps
+  hosts: 127.0.0.1
+  connection: local
+  become: yes
+
+- import_playbook: packages.yaml
+- import_playbook: node.yaml
+- import_playbook: rust.yaml
+- import_playbook: rubygems.yaml
+- import_playbook: repos.yaml
+- import_playbook: brother_printers.yaml
+- import_playbook: logrotate.yaml
+- import_playbook: disable_services.yaml

--- a/playbooks/trusted_build/cacvote_build.yaml
+++ b/playbooks/trusted_build/cacvote_build.yaml
@@ -1,5 +1,5 @@
 ---
-- name: All the trusted build steps
+- name: All the cacvote system level build steps
   hosts: 127.0.0.1
   connection: local
   become: yes
@@ -10,6 +10,7 @@
 - import_playbook: rust_targets.yaml
 - import_playbook: rubygems.yaml
 - import_playbook: repos.yaml
+- import_playbook: cacvote_label_printer.yaml
 - import_playbook: brother_printers.yaml
 - import_playbook: logrotate.yaml
 - import_playbook: disable_services.yaml

--- a/playbooks/trusted_build/cacvote_build.yaml
+++ b/playbooks/trusted_build/cacvote_build.yaml
@@ -7,6 +7,7 @@
 - import_playbook: packages.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml
+- import_playbook: rust_targets.yaml
 - import_playbook: rubygems.yaml
 - import_playbook: repos.yaml
 - import_playbook: brother_printers.yaml

--- a/playbooks/trusted_build/cacvote_label_printer.yaml
+++ b/playbooks/trusted_build/cacvote_label_printer.yaml
@@ -1,0 +1,33 @@
+---
+
+- name: Install CACvote Label Printer Driver
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+    - import_tasks: shared_tasks/user_to_configure.yaml
+    - import_tasks: shared_tasks/well_known_paths.yaml
+
+    - name: Download the label printer driver
+      ansible.builtin.get_url:
+        url: "https://www.idprt.com/prt_v2/files/down_file/id/131/fid/432.html"
+        dest: "{{ downloads_directory }}/idprt_tspl_printer_linux_driver_v1.4.2.zip"
+      tags:
+        - online
+
+    - name: Extract the driver
+      ansible.builtin.unarchive:
+        src: "{{ downloads_directory }}/idprt_tspl_printer_linux_driver_v1.4.2.zip"
+        dest: "{{ downloads_directory }}"
+        remote_src: yes
+      tags:
+        - offline
+
+    - name: Install the driver
+      ansible.builtin.shell:
+        cmd: "bash install"
+        chdir: "{{ downloads_directory }}/idprt_tspl_printer_linux_driver_v1.4.2"
+      tags:
+        - offline
+

--- a/playbooks/trusted_build/cacvote_label_printer.yaml
+++ b/playbooks/trusted_build/cacvote_label_printer.yaml
@@ -9,6 +9,10 @@
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
 
+    - name: Define downloads_directory from well_known_paths
+      set_fact:
+        downloads_directory: "{{ well_known_paths['tools']['system_path'] }}"
+
     - name: Download the label printer driver
       ansible.builtin.get_url:
         url: "https://www.idprt.com/prt_v2/files/down_file/id/131/fid/432.html"

--- a/playbooks/trusted_build/rust_targets.yaml
+++ b/playbooks/trusted_build/rust_targets.yaml
@@ -1,0 +1,57 @@
+---
+- name: Add Rust target(s)
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+
+    - import_tasks: shared_tasks/user_to_configure.yaml
+    - import_tasks: shared_tasks/well_known_paths.yaml
+
+    - name: Define downloads_directory from well_known_paths
+      set_fact:
+        downloads_directory: "{{ well_known_paths['tools']['system_path'] }}"
+
+    - name: Define the base URL pattern to download targets from
+      set_fact:
+        rust_base_url: "https://static.rust-lang.org/dist/rust-std-{{ rust_version }}"
+      tags:
+        - online
+
+    - name: Override user if local_user is defined
+      set_fact:
+        user_to_configure: "{{ local_user }}"
+      when: (local_user is defined) and (local_user|length > 0)
+
+    - name: Download Rust targets
+      ansible.builtin.get_url:
+        url: "{{ rust_base_url }}-{{ item }}.tar.gz"
+        dest: "{{ downloads_directory }}/{{ item }}.tar.gz"
+      retries: 3
+      delay: 2
+      register: rust_target_download
+      until: rust_target_download is not failed
+      loop: "{{ targets_to_add }}"
+      tags:
+        - online
+
+    - name: Extract Rust targets to tmp location
+      ansible.builtin.unarchive:
+        src: "{{ downloads_directory }}/{{ item }}.tar.gz"
+        dest: /var/tmp
+        remote_src: yes
+      become: true
+      become_user: "{{ user_to_configure }}"
+      loop: "{{ targets_to_add }}"
+      tags:
+        - offline
+
+    - name: Copy Rust targets to local user install path
+      ansible.builtin.shell:
+        cmd: "mv {{ downloads_directory }}/rust-{{ rust_version }}-{{ item }}/rust-std-{{ item }}/lib/rustlib/{{ item }} ~{{ user_to_configure }}/.cargo/lib/rustlib/"
+      become: true
+      become_user: "{{ user_to_configure }}"
+      loop: "{{ targets_to_add }}"
+      tags:
+        - offline

--- a/playbooks/trusted_build/rust_targets.yaml
+++ b/playbooks/trusted_build/rust_targets.yaml
@@ -49,7 +49,7 @@
 
     - name: Copy Rust targets to local user install path
       ansible.builtin.shell:
-        cmd: "mv /var/tmp/rust-{{ rust_version }}-{{ item }}/rust-std-{{ item }}/lib/rustlib/{{ item }} ~{{ user_to_configure }}/.cargo/lib/rustlib/"
+        cmd: "mv /var/tmp/rust-std-{{ rust_version }}-{{ item }}/rust-std-{{ item }}/lib/rustlib/{{ item }} ~{{ user_to_configure }}/.cargo/lib/rustlib/"
       become: true
       become_user: "{{ user_to_configure }}"
       loop: "{{ targets_to_add }}"

--- a/playbooks/trusted_build/rust_targets.yaml
+++ b/playbooks/trusted_build/rust_targets.yaml
@@ -39,7 +39,7 @@
     - name: Extract Rust targets to tmp location
       ansible.builtin.unarchive:
         src: "{{ downloads_directory }}/{{ item }}.tar.gz"
-        dest: "{{ downloads_directory }}"
+        dest: /var/tmp
         remote_src: yes
       become: true
       become_user: "{{ user_to_configure }}"
@@ -49,7 +49,7 @@
 
     - name: Copy Rust targets to local user install path
       ansible.builtin.shell:
-        cmd: "mv {{ downloads_directory }}/rust-{{ rust_version }}-{{ item }}/rust-std-{{ item }}/lib/rustlib/{{ item }} ~{{ user_to_configure }}/.cargo/lib/rustlib/"
+        cmd: "mv /var/tmp/rust-{{ rust_version }}-{{ item }}/rust-std-{{ item }}/lib/rustlib/{{ item }} ~{{ user_to_configure }}/.cargo/lib/rustlib/"
       become: true
       become_user: "{{ user_to_configure }}"
       loop: "{{ targets_to_add }}"

--- a/playbooks/trusted_build/rust_targets.yaml
+++ b/playbooks/trusted_build/rust_targets.yaml
@@ -39,7 +39,7 @@
     - name: Extract Rust targets to tmp location
       ansible.builtin.unarchive:
         src: "{{ downloads_directory }}/{{ item }}.tar.gz"
-        dest: /var/tmp
+        dest: "{{ downloads_directory }}"
         remote_src: yes
       become: true
       become_user: "{{ user_to_configure }}"

--- a/playbooks/virtmanager/create-base-vm.yaml
+++ b/playbooks/virtmanager/create-base-vm.yaml
@@ -15,18 +15,27 @@
       set_fact:
         vm_cpus: "{{ (ansible_facts['processor_nproc'] * 0.80)|round(0, 'floor')|int }}"
 
-    - name: Download Debian ISO from current url
-      get_url: 
-        url: "{{ current_url }}/{{ iso_name }}"
-        dest: "{{ virt_image_path }}/{{ iso_name }}"
-      register: current_download
-      ignore_errors: true
+    - name: Check if the Debian ISO is already downloaded
+      ansible.builtin.stat:
+        path: "{{ virt_image_path }}/{{ iso_name }}"
+      register: debian_iso_file
 
-    - name: Download Debian ISO from archive url if current was not available
-      get_url: 
-        url: "{{ iso_url }}/{{ iso_name }}"
-        dest: "{{ virt_image_path }}/{{ iso_name }}"
-      when: current_download.status_code == 404 
+    - name: Download the Debian ISO if not already downloaded
+      block:
+        - name: Download Debian ISO from current url
+          get_url: 
+            url: "{{ current_url }}/{{ iso_name }}"
+            dest: "{{ virt_image_path }}/{{ iso_name }}"
+          register: current_download
+          ignore_errors: true
+
+        - name: Download Debian ISO from archive url if current was not available
+          get_url: 
+            url: "{{ iso_url }}/{{ iso_name }}"
+            dest: "{{ virt_image_path }}/{{ iso_name }}"
+          when: current_download.status_code == 404 
+
+      when: not debian_iso_file.stat.exists or not debian_iso_file.stat.isreg
 
     - name: See if virt networking is active
       shell: 

--- a/preseeds/cacvote-prod-preseed.cfg
+++ b/preseeds/cacvote-prod-preseed.cfg
@@ -1,0 +1,466 @@
+#_preseed_V1
+#### Contents of the preconfiguration file (for bullseye)
+### Localization
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US
+
+# The values can also be preseeded individually for greater flexibility.
+#d-i debian-installer/language string en
+#d-i debian-installer/country string NL
+#d-i debian-installer/locale string en_GB.UTF-8
+# Optionally specify additional locales to be generated.
+#d-i localechooser/supported-locales multiselect en_US.UTF-8, nl_NL.UTF-8
+
+# Keyboard selection.
+d-i keyboard-configuration/xkb-keymap select us
+# d-i keyboard-configuration/toggle select No toggling
+
+### Network configuration
+# Disable network configuration entirely. This is useful for cdrom
+# installations on non-networked devices where the network questions,
+# warning and long timeouts are a nuisance.
+#d-i netcfg/enable boolean false
+
+# netcfg will choose an interface that has link if possible. This makes it
+# skip displaying a list if there is more than one interface.
+d-i netcfg/choose_interface select auto
+
+# To pick a particular interface instead:
+#d-i netcfg/choose_interface select eth1
+
+# To set a different link detection timeout (default is 3 seconds).
+# Values are interpreted as seconds.
+#d-i netcfg/link_wait_timeout string 10
+
+# If you have a slow dhcp server and the installer times out waiting for
+# it, this might be useful.
+#d-i netcfg/dhcp_timeout string 60
+#d-i netcfg/dhcpv6_timeout string 60
+
+# If you prefer to configure the network manually, uncomment this line and
+# the static network configuration below.
+#d-i netcfg/disable_autoconfig boolean true
+
+# If you want the preconfiguration file to work on systems both with and
+# without a dhcp server, uncomment these lines and the static network
+# configuration below.
+#d-i netcfg/dhcp_failed note
+#d-i netcfg/dhcp_options select Configure network manually
+
+# Static network configuration.
+#
+# IPv4 example
+#d-i netcfg/get_ipaddress string 192.168.1.42
+#d-i netcfg/get_netmask string 255.255.255.0
+#d-i netcfg/get_gateway string 192.168.1.1
+#d-i netcfg/get_nameservers string 192.168.1.1
+#d-i netcfg/confirm_static boolean true
+#
+# IPv6 example
+#d-i netcfg/get_ipaddress string fc00::2
+#d-i netcfg/get_netmask string ffff:ffff:ffff:ffff::
+#d-i netcfg/get_gateway string fc00::1
+#d-i netcfg/get_nameservers string fc00::1
+#d-i netcfg/confirm_static boolean true
+
+# Any hostname and domain names assigned from dhcp take precedence over
+# values set here. However, setting the values still prevents the questions
+# from being shown, even if values come from dhcp.
+d-i netcfg/get_hostname string CACvote
+d-i netcfg/get_domain string unassigned-domain
+
+# If you want to force a hostname, regardless of what either the DHCP
+# server returns or what the reverse DNS entry for the IP is, uncomment
+# and adjust the following line.
+#d-i netcfg/hostname string somehost
+
+# Disable that annoying WEP key dialog.
+d-i netcfg/wireless_wep string
+# The wacky dhcp hostname that some ISPs use as a password of sorts.
+#d-i netcfg/dhcp_hostname string radish
+
+# If non-free firmware is needed for the network or other hardware, you can
+# configure the installer to always try to load it, without prompting. Or
+# change to false to disable asking.
+#d-i hw-detect/load_firmware boolean true
+
+### Network console
+# Use the following settings if you wish to make use of the network-console
+# component for remote installation over SSH. This only makes sense if you
+# intend to perform the remainder of the installation manually.
+#d-i anna/choose_modules string network-console
+#d-i network-console/authorized_keys_url string http://10.0.0.1/openssh-key
+#d-i network-console/password password r00tme
+#d-i network-console/password-again password r00tme
+
+### Mirror settings
+# If you select ftp, the mirror/country string does not need to be set.
+#d-i mirror/protocol string ftp
+d-i mirror/country string manual
+d-i mirror/http/hostname string http.us.debian.org
+d-i mirror/http/directory string /debian
+d-i mirror/http/proxy string
+
+# Suite to install.
+#d-i mirror/suite string testing
+# Suite to use for loading installer components (optional).
+#d-i mirror/udeb/suite string testing
+
+### Account setup
+# Skip creation of a root account (normal user account will be able to
+# use sudo).
+d-i passwd/root-login boolean false
+# Alternatively, to skip creation of a normal user account.
+#d-i passwd/make-user boolean false
+
+# Root password, either in clear text
+#d-i passwd/root-password password r00tme
+#d-i passwd/root-password-again password r00tme
+# or encrypted using a crypt(3)  hash.
+#d-i passwd/root-password-crypted password [crypt(3) hash]
+
+# To create a normal user account.
+d-i passwd/user-fullname string vx
+d-i passwd/username string vx
+# Normal user's password, either in clear text
+d-i passwd/user-password password votingworks
+d-i passwd/user-password-again password votingworks
+# or encrypted using a crypt(3) hash.
+#d-i passwd/user-password-crypted password [crypt(3) hash]
+# Create the first user with the specified UID instead of the default.
+#d-i passwd/user-uid string 1010
+
+# The user account will be added to some standard initial groups. To
+# override that, use this.
+# TODO: figure out what the right groups are
+# d-i passwd/user-default-groups string audio cdrom video sudo lpadmin cups
+
+### Clock and time zone setup
+# Controls whether or not the hardware clock is set to UTC.
+d-i clock-setup/utc boolean true
+
+# You may set this to any valid setting for $TZ; see the contents of
+# /usr/share/zoneinfo/ for valid values.
+d-i time/zone string US/Eastern
+
+# Controls whether to use NTP to set the clock during the install
+d-i clock-setup/ntp boolean true
+# NTP server to use. The default is almost always fine here.
+#d-i clock-setup/ntp-server string ntp.example.com
+
+### Partitioning
+## Partitioning example
+# If the system has free space you can choose to only partition that space.
+# This is only honoured if partman-auto/method (below) is not set.
+#d-i partman-auto/init_automatically_partition select biggest_free
+
+# Alternatively, you may specify a disk to partition. If the system has only
+# one disk the installer will default to using that, but otherwise the device
+# name must be given in traditional, non-devfs format (so e.g. /dev/sda
+# and not e.g. /dev/discs/disc0/disc).
+# For example, to use the first SCSI/SATA hard disk:
+#d-i partman-auto/disk string /dev/sda
+# In addition, you'll need to specify the method to use.
+# The presently available methods are:
+# - regular: use the usual partition types for your architecture
+# - lvm:     use LVM to partition the disk
+# - crypto:  use LVM within an encrypted partition
+d-i partman-auto/method string lvm
+
+# You can define the amount of space that will be used for the LVM volume
+# group. It can either be a size with its unit (eg. 20 GB), a percentage of
+# free space or the 'max' keyword.
+d-i partman-auto-lvm/guided_size string max
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+d-i partman-lvm/device_remove_lvm boolean true
+# The same applies to preexisting software RAID array:
+d-i partman-md/device_remove_md boolean true
+# And the same goes for the confirmation to write the lvm partitions.
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+# Or provide a recipe of your own...
+# If you have a way to get a recipe file into the d-i environment, you can
+# just point at it.
+#d-i partman-auto/expert_recipe_file string /hd-media/recipe
+
+# If not, you can put an entire recipe into the preconfiguration file in one
+# (logical) line. This example creates a small /boot partition, suitable
+# swap, and uses the rest of the space for the root partition:
+#d-i partman-auto/expert_recipe string                         \
+#      boot-root ::                                            \
+#              40 50 100 ext3                                  \
+#                      $primary{ } $bootable{ }                \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ /boot }                     \
+#              .                                               \
+#              500 10000 1000000000 ext3                       \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ / }                         \
+#              .                                               \
+#              64 512 300% linux-swap                          \
+#                      method{ swap } format{ }                \
+#              .
+#
+# The full recipe format is documented in the file partman-auto-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository. This also documents how to specify settings such as file
+# system labels, volume group names and which physical devices to include
+# in a volume group.
+#d-i partman-auto-lvm/new_vg_name multiselect Vx-vg
+
+## Partitioning for EFI
+# If your system needs an EFI partition you could add something like
+# this to the recipe above, as the first element in the recipe:
+#               538 538 1075 free                              \
+#                      $iflabel{ gpt }                         \
+#                      $reusemethod{ }                         \
+#                      method{ efi }                           \
+#                      format{ }                               \
+#               .                                              \
+#
+# The fragment above is for the amd64 architecture; the details may be
+# different on other architectures. The 'partman-auto' package in the
+# D-I source repository may have an example you can follow.
+
+# Modified from here: https://secopsmonkey.com/custom-partioning-using-preseed.html
+# note the numbers are partition sizes, in megabytes. The middle number is a "priority", which
+# the installer uses as a hint for which end of the range to shoot for. Tuning "priority" involves
+# some black magic, so proceed with extreme caution and be prepared for lots of trial and error. 
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+# d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+# Force UEFI booting ('BIOS compatibility' will be lost). Default: false.
+d-i partman-efi/non_efi_system boolean true
+# Ensure the partition table is GPT - this is required for EFI
+d-i partman-partitioning/choose_label string gpt
+d-i partman-partitioning/default_label string gpt
+
+# When disk encryption is enabled, skip wiping the partitions beforehand.
+#d-i partman-auto-crypto/erase_disks boolean false
+
+## Partitioning using RAID
+# The method should be set to "raid".
+#d-i partman-auto/method string raid
+# Specify the disks to be partitioned. They will all get the same layout,
+# so this will only work if the disks are the same size.
+#d-i partman-auto/disk string /dev/sda /dev/sdb
+#d-i partman/early_command string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+
+# Next you need to specify the physical partitions that will be used. 
+#d-i partman-auto/expert_recipe string \
+#      multiraid ::                                         \
+#              1000 5000 4000 raid                          \
+#                      $primary{ } method{ raid }           \
+#              .                                            \
+#              64 512 300% raid                             \
+#                      method{ raid }                       \
+#              .                                            \
+#              500 10000 1000000000 raid                    \
+#                      method{ raid }                       \
+#              .
+
+# Last you need to specify how the previously defined partitions will be
+# used in the RAID setup. Remember to use the correct partition numbers
+# for logical partitions. RAID levels 0, 1, 5, 6 and 10 are supported;
+# devices are separated using "#".
+# Parameters are:
+# <raidtype> <devcount> <sparecount> <fstype> <mountpoint> \
+#          <devices> <sparedevices>
+
+#d-i partman-auto-raid/recipe string \
+#    1 2 0 ext3 /                    \
+#          /dev/sda1#/dev/sdb1       \
+#    .                               \
+#    1 2 0 swap -                    \
+#          /dev/sda5#/dev/sdb5       \
+#    .                               \
+#    0 2 0 ext3 /home                \
+#          /dev/sda6#/dev/sdb6       \
+#    .
+
+# For additional information see the file partman-auto-raid-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository.
+
+# This makes partman automatically partition without confirmation.
+# d-i partman-md/confirm boolean true
+# d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+# Ignore no swap
+d-i partman-basicfilesystems/no_swap boolean false
+
+## Controlling how partitions are mounted
+# The default is to mount by UUID, but you can also choose "traditional" to
+# use traditional device names, or "label" to try filesystem labels before
+# falling back to UUIDs.
+#d-i partman/mount_style select uuid
+
+### Base system installation
+# Configure APT to not install recommended packages by default. Use of this
+# option can result in an incomplete system and should only be used by very
+# experienced users.
+# d-i base-installer/install-recommends boolean false
+
+# The kernel image (meta) package to be installed; "none" can be used if no
+# kernel is to be installed.
+#d-i base-installer/kernel/image string linux-image-686
+
+### Apt setup
+# You can choose to install non-free and contrib software.
+#d-i apt-setup/non-free boolean true
+#d-i apt-setup/contrib boolean true
+# Uncomment this if you don't want to use a network mirror.
+#d-i apt-setup/use_mirror boolean false
+# Select which update services to use; define the mirrors to be used.
+# Values shown below are the normal defaults.
+#d-i apt-setup/services-select multiselect security, updates
+#d-i apt-setup/security_host string security.debian.org
+
+# Additional repositories, local[0-9] available
+#d-i apt-setup/local0/repository string \
+#       http://local.server/debian stable main
+#d-i apt-setup/local0/comment string local server
+# Enable deb-src lines
+#d-i apt-setup/local0/source boolean true
+# URL to the public key of the local repository; you must provide a key or
+# apt will complain about the unauthenticated repository and so the
+# sources.list line will be left commented out.
+#d-i apt-setup/local0/key string http://local.server/key
+# If the provided key file ends in ".asc" the key file needs to be an
+# ASCII-armoured PGP key, if it ends in ".gpg" it needs to use the
+# "GPG key public keyring" format, the "keybox database" format is
+# currently not supported.
+
+# By default the installer requires that repositories be authenticated
+# using a known gpg key. This setting can be used to disable that
+# authentication. Warning: Insecure, not recommended.
+#d-i debian-installer/allow_unauthenticated boolean true
+
+# Uncomment this to add multiarch configuration for i386
+#d-i apt-setup/multiarch string i386
+
+
+### Package selection
+#tasksel tasksel/first multiselect standard, web-server, kde-desktop
+tasksel tasksel/first multiselect standard, gnome-desktop, ssh-server
+
+# Individual additional packages to install
+d-i pkgsel/include string sudo curl git vim git build-essential rsync gpg gpg-agent
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+#d-i pkgsel/upgrade select none
+
+# Some versions of the installer can report back on what software you have
+# installed, and what software you use. The default is not to report back,
+# but sending reports helps the project determine what software is most
+# popular and should be included on the first CD/DVD.
+#popularity-contest popularity-contest/participate boolean false
+
+### Boot loader installation
+# Grub is the boot loader (for x86).
+
+# This is fairly safe to set, it makes grub install automatically to the UEFI
+# partition/boot record if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# This one makes grub-installer install to the UEFI partition/boot record, if
+# it also finds some other OS, which is less safe as it might not be able to
+# boot that other OS.
+d-i grub-installer/with_other_os boolean true
+
+# Due notably to potential USB sticks, the location of the primary drive can
+# not be determined safely in general, so this needs to be specified:
+#d-i grub-installer/bootdev  string /dev/sda
+# To install to the primary device (assuming it is not a USB stick):
+#d-i grub-installer/bootdev  string default
+
+# Alternatively, if you want to install to a location other than the UEFI
+# partition/boot record, uncomment and edit these lines:
+#d-i grub-installer/only_debian boolean false
+#d-i grub-installer/with_other_os boolean false
+#d-i grub-installer/bootdev  string (hd0,1)
+# To install grub to multiple disks:
+#d-i grub-installer/bootdev  string (hd0,1) (hd1,1) (hd2,1)
+
+# Optional password for grub, either in clear text
+#d-i grub-installer/password password r00tme
+#d-i grub-installer/password-again password r00tme
+# or encrypted using an MD5 hash, see grub-md5-crypt(8).
+#d-i grub-installer/password-crypted password [MD5 hash]
+
+# Use the following option to add additional boot parameters for the
+# installed system (if supported by the bootloader installer).
+# Note: options passed to the installer will be added automatically.
+#d-i debian-installer/add-kernel-opts string nousb
+
+### Finishing up the installation
+# During installations from serial console, the regular virtual consoles
+# (VT1-VT6) are normally disabled in /etc/inittab. Uncomment the next
+# line to prevent this.
+#d-i finish-install/keep-consoles boolean true
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+# This will prevent the installer from ejecting the CD during the reboot,
+# which is useful in some situations.
+#d-i cdrom-detect/eject boolean false
+
+# This is how to make the installer shutdown when finished, but not
+# reboot into the installed system.
+#d-i debian-installer/exit/halt boolean true
+# This will power off the machine instead of just halting it.
+d-i debian-installer/exit/poweroff boolean true
+
+### Preseeding other packages
+# Depending on what software you choose to install, or if things go wrong
+# during the installation process, it's possible that other questions may
+# be asked. You can preseed those too, of course. To get a list of every
+# possible question that could be asked during an install, do an
+# installation, and then run these commands:
+#   debconf-get-selections --installer > file
+#   debconf-get-selections >> file
+
+
+#### Advanced options
+### Running custom commands during the installation
+# d-i preseeding is inherently not secure. Nothing in the installer checks
+# for attempts at buffer overflows or other exploits of the values of a
+# preconfiguration file like this one. Only use preconfiguration files from
+# trusted locations! To drive that home, and because it's generally useful,
+# here's a way to run any shell command you'd like inside the installer,
+# automatically.
+
+# This first command is run as early as possible, just after
+# preseeding is read.
+#d-i preseed/early_command string anna-install some-udeb
+# This command is run immediately before the partitioner starts. It may be
+# useful to apply dynamic partitioner preseeding that depends on the state
+# of the disks (which may not be visible when preseed/early_command runs).
+#d-i partman/early_command \
+#       string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+# This command is run just before the install finishes, but when there is
+# still a usable /target directory. You can chroot to /target and use it
+# directly, or use the apt-install and in-target commands to easily install
+# packages and run commands in the target system.
+

--- a/scripts/tb-cacvote.sh
+++ b/scripts/tb-cacvote.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
+local_user=`logname`
+local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
+vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
+kiosk_browser_dir="${local_user_home_dir}/code/kiosk-browser"
+
+ansible_inventory=$1
+
+if [[ ! -d ${vxsuite_build_system_dir}/inventories/${ansible_inventory} ]]; then
+  echo "ERROR: The $ansible_inventory inventory could not be found."
+  echo "You can find a list of inventories in: ${vxsuite_build_system_dir}/inventories"
+  exit 1
+fi
+
+if [[ ! -d $vxsuite_build_system_dir ]]; then
+  echo "ERROR: vxsuite-build-system could not be found."
+  exit 1
+fi
+
+if [[ ! -f .virtualenv/ansible/bin/activate ]]; then
+  echo "Installing Ansible..."
+  cd $vxsuite_build_system_dir
+  sudo ./scripts/tb-install-ansible.sh online
+  echo "Ansible installation is complete."
+fi
+
+cd $vxsuite_build_system_dir
+
+if [[ "$debian_major_version" == "12" ]]; then
+  source .virtualenv/ansible/bin/activate
+fi
+
+echo "Run cacvote_build playbook. This will take several minutes."
+sleep 5
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/cacvote_build.yaml
+
+if [[ ! -d $kiosk_browser_dir ]]; then
+  echo "ERROR: kiosk-browser directory could not be found."
+  exit 1
+fi
+
+echo "Build kiosk-browser"
+sleep 5
+cd $kiosk_browser_dir
+make install
+make build
+sudo dpkg -i dist/kiosk-browser_1.0.0_*.deb
+
+exit 0


### PR DESCRIPTION
This PR sets up the initial build system scripts and playbooks for production [CACvote](https://github.com/votingworks/cacvote). Although Trusted Build is not a requirement (yet), an effort has been made to follow those processes as much as possible. 

Notes:

- The preseed currently includes gnome for testing convenience. It will be removed for official production builds.
- The preseed does not include a partition schema yet for production use. For testing convenience, the entire disk is allocated to the root partition. Once the build is closer to an official production build, the partitions will be defined as appropriate. 
- The label printer playbook is hardcoded to the single driver we currently use. That may change to mirror the brother printer playbook in the future if we add more label printer options.
- An option was added to the brother printer playbook to delete via lpadmin. We need to do that in vxsuite, but we do not do that in cacvote, so cacvote brother printers are configured to not delete via lpadmin. 
- The QL-1100 printer driver is very fragile. If you attempt to re-run the brother printer playbook, it will error and require manual intervention to correct. It may make sense to check for an already installed/configured QL-1100 and skip, but that will be a future decision.