### PR TITLE
fix: update apt cache before `apt-get install`

### DIFF
--- a/playbooks/install-vxsuite-packages.yaml
+++ b/playbooks/install-vxsuite-packages.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install system level dependencies used by various apps and services
   hosts: 127.0.0.1
   connection: local
@@ -74,7 +73,9 @@
       - zip
 
   tasks:
-
+    - name: Update apt cache
+      ansible.builtin.command:
+        cmd: "apt-get update"
     - name: Install all necessary system packages
       ansible.builtin.command:
         cmd: "apt-get -y --no-install-recommends install {{ all_packages | join(' ') }}"


### PR DESCRIPTION
Without this we were hitting 404s when trying to fetch `.deb` packages. See https://votingworks.slack.com/archives/C04RWBCCTCZ/p1710347032819589.