### PR TITLE
bump debian 12 docker container versions

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "3.0.1"
+  default = "3.0.2"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "3.0.1"
+  default = "3.0.2"
 }
 
 source "docker" "debian12" {


### PR DESCRIPTION
This should have been part of https://github.com/votingworks/vxsuite-build-system/pull/110.