### PR TITLE
Base build script for cacvote apps

### DIFF
--- a/playbooks/trusted_build/rust_targets.yaml
+++ b/playbooks/trusted_build/rust_targets.yaml
@@ -47,6 +47,16 @@
       tags:
         - offline
 
+    - name: Remove existing targets in the local path to ensure re-runs work
+      ansible.builtin.file:
+        path: "~{{ user_to_configure }}/.cargo/lib/rustlib/{{ item }}"
+        state: absent
+      become: true
+      become_user: "{{ user_to_configure }}"
+      loop: "{{ targets_to_add }}"
+      tags:
+        - offline
+
     - name: Copy Rust targets to local user install path
       ansible.builtin.shell:
         cmd: "mv /var/tmp/rust-std-{{ rust_version }}-{{ item }}/rust-std-{{ item }}/lib/rustlib/{{ item }} ~{{ user_to_configure }}/.cargo/lib/rustlib/"

--- a/scripts/build-cacvote-apps.sh
+++ b/scripts/build-cacvote-apps.sh
@@ -90,4 +90,14 @@ cargo build
 make -C apps/cacvote-jx-terminal dist
 make -C apps/cacvote-mark build
 
+# Create the prod-build link if not present
+if [[ ! -L "${cacvote_dir}/apps/cacvote-mark/frontend/script/prod-build" ]]; then
+  ln -s ${cacvote_dir/script/prod-build ${cacvote_dir}/apps/cacvote-mark/frontend/script/prod-build
+fi
+
+export BUILD_ROOT="${cacvote_dir}/build/cacvote-mark"
+rm -rf "${BUILD_ROOT}"
+cd "${cacvote_dir}/apps/cacvote-mark/frontend"
+./script/prod-build
+
 exit 0

--- a/scripts/build-cacvote-apps.sh
+++ b/scripts/build-cacvote-apps.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+local_user="$( logname )"
+local_user_home_dir="$( getent passwd "${local_user}" | cut -d: -f6 )"
+cacvote_dir="${local_user_home_dir}/code/cacvote"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [[ ! -d "$cacvote_dir" ]]; then
+  echo "Error: $cacvote_dir does not exist."
+  exit 1
+fi
+
+# Make sure PATH includes what we need for builds
+export PATH="${local_user_home_dir}/.cargo/bin:/sbin:/usr/local/bin:${PATH}"
+
+install_cargo_tools() {
+  echo "Installing cargo tools needed for build and migrations."
+
+  if ! which sqlx >/dev/null 2>&1; then
+    cargo install --locked sqlx-cli
+  fi
+
+  if ! which dx >/dev/null 2>&1; then
+    cargo install --locked dioxus-cli
+  fi
+}
+
+configure-postgresql() {
+  echo "Configuring Postgres for cacvote-jx"
+  sudo systemctl enable postgresql --quiet
+  if ! systemctl is-active --quiet postgresql; then
+    sudo systemctl start postgresql
+  fi
+
+  echo "Determine if the current user has postgres superuser privileges."
+  IS_SUPER=$(
+    cd /tmp
+    sudo -u postgres psql postgres --tuples-only --quiet \
+      -c "select pg_user.usesuper from pg_catalog.pg_user where pg_user.usename = '${local_user}' limit 1;" | tr -d '[:space:]' || true
+  )
+
+  if [[ "$IS_SUPER" == "t" ]]; then
+    echo "User ${local_user} is already a postgres superuser."
+  elif [[ "$IS_SUPER" == "f" ]]; then
+    echo "Granting ${local_user} superuser privileges."
+    sudo -u postgres psql postgres --quiet -c "alter user ${local_user} with superuser;"
+  else
+    echo "Creating ${local_user} with superuser privileges."
+    sudo -u postgres createuser --superuser "${local_user}"
+  fi
+
+  for database in cacvote cacvote_jx; do
+    local DB_EXISTS=$(psql postgres --quiet --tuples-only \
+      -c "select count(*) from pg_database where datistemplate = false and datname = '${database}'" | tr -d '[:space:]'
+    )
+
+    if [[ "${DB_EXISTS}" == "0" ]]; then
+      echo "Creating database: ${database}"
+      createdb "${database}"
+    else
+      echo "Database ${database} already exists."
+    fi
+  done
+
+  echo "Apply database migrations."
+  cd "${cacvote_dir}/apps/cacvote-jx-terminal/backend"
+  cargo sqlx migrate run --source db/migrations --database-url "postgres:cacvote_jx"
+
+  echo "Postgres configuration is complete."
+
+}
+
+echo "User: $local_user"
+echo "Dir: $DIR"
+echo "Home: $local_user_home_dir"
+echo "Done"
+
+install-cargo-tools
+cd "${cacvote_dir}"
+pnpm install
+cargo build
+
+exit 0

--- a/scripts/build-cacvote-apps.sh
+++ b/scripts/build-cacvote-apps.sh
@@ -41,6 +41,7 @@ configure_postgresql() {
       -c "select pg_user.usesuper from pg_catalog.pg_user where pg_user.usename = '${local_user}' limit 1;" | tr -d '[:space:]' || true
   )
 
+  cd /tmp
   if [[ "$IS_SUPER" == "t" ]]; then
     echo "User ${local_user} is already a postgres superuser."
   elif [[ "$IS_SUPER" == "f" ]]; then
@@ -85,5 +86,8 @@ configure_postgresql
 cd "${cacvote_dir}"
 pnpm install
 cargo build
+
+make -C apps/cacvote-jx-terminal dist
+make -C apps/cacvote-mark build
 
 exit 0

--- a/scripts/build-cacvote-apps.sh
+++ b/scripts/build-cacvote-apps.sh
@@ -19,11 +19,11 @@ install_cargo_tools() {
   echo "Installing cargo tools needed for build and migrations."
 
   if ! which sqlx >/dev/null 2>&1; then
-    cargo install --locked sqlx-cli
+    cargo install sqlx-cli
   fi
 
   if ! which dx >/dev/null 2>&1; then
-    cargo install --locked dioxus-cli
+    cargo install dioxus-cli
   fi
 }
 

--- a/scripts/build-cacvote-apps.sh
+++ b/scripts/build-cacvote-apps.sh
@@ -92,7 +92,7 @@ make -C apps/cacvote-mark build
 
 # Create the prod-build link if not present
 if [[ ! -L "${cacvote_dir}/apps/cacvote-mark/frontend/script/prod-build" ]]; then
-  ln -s ${cacvote_dir/script/prod-build ${cacvote_dir}/apps/cacvote-mark/frontend/script/prod-build
+  ln -s ${cacvote_dir}/script/prod-build ${cacvote_dir}/apps/cacvote-mark/frontend/script/prod-build
 fi
 
 export BUILD_ROOT="${cacvote_dir}/build/cacvote-mark"

--- a/scripts/build-cacvote-apps.sh
+++ b/scripts/build-cacvote-apps.sh
@@ -27,7 +27,7 @@ install_cargo_tools() {
   fi
 }
 
-configure-postgresql() {
+configure_postgresql() {
   echo "Configuring Postgres for cacvote-jx"
   sudo systemctl enable postgresql --quiet
   if ! systemctl is-active --quiet postgresql; then
@@ -65,6 +65,8 @@ configure-postgresql() {
   done
 
   echo "Apply database migrations."
+  cd "${cacvote_dir}/services/cacvote-server"
+  cargo sqlx migrate run --source db/migrations --database-url "postgres:cacvote"
   cd "${cacvote_dir}/apps/cacvote-jx-terminal/backend"
   cargo sqlx migrate run --source db/migrations --database-url "postgres:cacvote_jx"
 
@@ -77,7 +79,9 @@ echo "Dir: $DIR"
 echo "Home: $local_user_home_dir"
 echo "Done"
 
-install-cargo-tools
+install_cargo_tools
+configure_postgresql
+
 cd "${cacvote_dir}"
 pnpm install
 cargo build


### PR DESCRIPTION
This PR creates the base build script for creating production releases of cacvote. As noted in the script, it will continue to change over time as we refine the scope, but this covers the initial requirements for local testing. Configuring environments, setting up appropriate users, run scripts, and more will be in future PRs.