### PR TITLE
Fix Chinese font rendering in prod

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -20,6 +20,7 @@ all_packages:
   - firmware-linux-free
   - firmware-misc-nonfree
   - firmware-sof-signed
+  - fonts-wqy-zenhei
   - git
   - gvfs
   - gzip

--- a/inventories/vsap/group_vars/all/packages.yaml
+++ b/inventories/vsap/group_vars/all/packages.yaml
@@ -20,6 +20,7 @@ all_packages:
   - firmware-linux-free
   - firmware-misc-nonfree
   - firmware-sof-signed
+  - fonts-wqy-zenhei
   - git
   - gvfs
   - gzip


### PR DESCRIPTION
All Chinese characters are showing up as squares on a prod VSAP/VxMarkScan that we just imaged. Running `sudo apt install fonts-wqy-zenhei` fixed the font rendering. My hunch is that another package that we install used to implicitly install `fonts-wqy-zenhei` but now doesn't. Quick fix! And I _think_ yet another example of why we want to self host apt repos.