### PR TITLE
upgrade pnpm to 8.3.1

### DIFF
--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.15"
     checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
   pnpm:
-    version: "8.1.0"
-    checksum: "09ebf306075e96037432071992bb00340c263d85"
+    version: "8.3.1"
+    checksum: "75c6e8a4075abfc494770f998bf37b9ada110f51"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.15"
     checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
   pnpm:
-    version: "8.1.0"
-    checksum: "09ebf306075e96037432071992bb00340c263d85"
+    version: "8.3.1"
+    checksum: "75c6e8a4075abfc494770f998bf37b9ada110f51"

--- a/inventories/vsap/group_vars/all/node.yaml
+++ b/inventories/vsap/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.15"
     checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
   pnpm:
-    version: "8.1.0"
-    checksum: "09ebf306075e96037432071992bb00340c263d85"
+    version: "8.3.1"
+    checksum: "75c6e8a4075abfc494770f998bf37b9ada110f51"

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.15"
     checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
   pnpm:
-    version: "8.1.0"
-    checksum: "09ebf306075e96037432071992bb00340c263d85"
+    version: "8.3.1"
+    checksum: "75c6e8a4075abfc494770f998bf37b9ada110f51"

--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -8,7 +8,7 @@
     node_version: "16.19.1"
     npm_packages:
       - yarn@1.22.15
-      - pnpm@8.1.0
+      - pnpm@8.3.1
 
   tasks:
 

--- a/playbooks/install-vxsuite-packages.yaml
+++ b/playbooks/install-vxsuite-packages.yaml
@@ -55,6 +55,7 @@
       - rsync
       - rsyslog
       - ruby
+      - ruby-dev
       - sbsigntool
       - swig
       - tar


### PR DESCRIPTION
This PR upgrades `pnpm` to version 8.3.1 in support of https://github.com/votingworks/vxsuite/pull/4941

Since our trusted build process requires the integrity of packages and package managers to be verified, the checksums were updated as well. It's noted within [playbooks/trusted_build/node.yaml](https://github.com/votingworks/vxsuite-build-system/blob/main/playbooks/trusted_build/node.yaml), but as a reminder, official checksums for npm packages can be retrieved via 
```
npm pack --dry-run pnpm@8.3.1
```