### PR TITLE
fix permissions issue and add ruby-dev to parallels inventory

### DIFF
--- a/inventories/parallels-latest/group_vars/all/packages.yaml
+++ b/inventories/parallels-latest/group_vars/all/packages.yaml
@@ -54,6 +54,7 @@ all_packages:
   - rsync
   - rsyslog
   - ruby
+  - ruby-dev
   - sbsigntool
   - swig
   - tar

--- a/parallels-debian12.pkr.hcl
+++ b/parallels-debian12.pkr.hcl
@@ -204,6 +204,7 @@ build {
     inline = [
       "echo 'packer' | TERM=xterm sudo -S mv /tmp/packer-sudo /etc/sudoers.d/packer",
       "echo 'packer' | TERM=xterm sudo -S chown root.root /etc/sudoers.d/packer",
+      "chmod 755 /home/packer",
     ]
   }
 
@@ -246,6 +247,4 @@ build {
     ]
   }
 }
-
-
 


### PR DESCRIPTION
When cloning repos, the `packer` user switches to the defined `local_user` (defaults to vx) since the repos are going to be cloned in the `local_user` directory structure. In the past, there was no issue with using the ansible `become` and `become_user` directives to perform this task. Something has changed, resulting in the `local_user` trying to run the python3 binary within the `packer` home directory, and by default, permission is denied. As a workaround, this PR modifies the `packer` home directory to have `755` permissions, enabling the task to run. 

The `ruby-dev` package has also been added to the parallels inventory since that is now a requirement for rubygems. 