### PR TITLE
Script vxdev image creation

### DIFF
--- a/preseeds/vxdev-preseed.cfg
+++ b/preseeds/vxdev-preseed.cfg
@@ -463,4 +463,7 @@ d-i debian-installer/exit/poweroff boolean true
 # still a usable /target directory. You can chroot to /target and use it
 # directly, or use the apt-install and in-target commands to easily install
 # packages and run commands in the target system.
-
+d-i preseed/late_command string \
+    mkdir -p /target/home/vx/.config; \
+    chown vx:vx /target/home/vx/.config; \
+    touch /target/home/vx/.config/gnome-initial-setup-done;

--- a/preseeds/vxdev-preseed.cfg
+++ b/preseeds/vxdev-preseed.cfg
@@ -464,6 +464,6 @@ d-i debian-installer/exit/poweroff boolean true
 # directly, or use the apt-install and in-target commands to easily install
 # packages and run commands in the target system.
 d-i preseed/late_command string \
-    mkdir -p /target/home/vx/.config; \
-    chown vx:vx /target/home/vx/.config; \
-    touch /target/home/vx/.config/gnome-initial-setup-done;
+    in-target mkdir -p /home/vx/.config; \
+    in-target chown vx:vx /home/vx/.config; \
+    in-target touch /home/vx/.config/gnome-initial-setup-done;

--- a/scripts/setup-vxdev.sh
+++ b/scripts/setup-vxdev.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
+local_user=`logname`
+local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
+vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
+vxsuite_complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
+
+ansible_inventory=$1
+
+if [[ ! -d ${vxsuite_build_system_dir}/inventories/${ansible_inventory} ]]; then
+  echo "ERROR: The $ansible_inventory inventory could not be found."
+  echo "You can find a list of inventories in: ${vxsuite_build_system_dir}/inventories"
+  exit 1
+fi
+
+if [[ ! -d $vxsuite_build_system_dir ]]; then
+  echo "ERROR: vxsuite-build-system could not be found."
+  exit 1
+fi
+
+if [[ ! -f .virtualenv/ansible/bin/activate ]]; then
+  echo "Installing Ansible..."
+  cd $vxsuite_build_system_dir
+  sudo ./scripts/tb-install-ansible.sh online
+  echo "Ansible installation is complete."
+fi
+
+cd $vxsuite_build_system_dir
+
+if [[ "$debian_major_version" == "12" ]]; then
+  source .virtualenv/ansible/bin/activate
+fi
+
+echo "Run setup_vxdev playbook. This will take several minutes."
+sleep 5
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/setup_vxdev.yaml
+
+if [[ ! -d $vxsuite_complete_system_dir ]]; then
+  echo "ERROR: vxsuite-complete-system could not be found."
+  exit 1
+fi
+
+echo "Run vxdev/setup-vxdev-base-machine.sh in complete-system. This will take several minutes."
+sleep 5
+cd $vxsuite_complete_system_dir
+sudo -v
+./vxdev/setup-vxdev-base-machine.sh
+
+# If in an interactive session, help set up the dock
+if [[ "${DESKTOP_SESSION}" == "gnome" ]]; then
+  echo "Please install the Dash to Dock extension from Firefox."
+  echo "Once you've done that, close Firefox to proceed."
+  sleep 5
+  firefox https://extensions.gnome.org/extension/307/dash-to-dock
+  gnome-extensions enable dash-to-dock@micxgx.gmail.com
+  dconf write /org/gnome/shell/extensions/dash-to-dock/dock-position "'LEFT'"
+  dconf write /org/gnome/shell/extensions/dash-to-dock/intellihide true
+fi
+
+echo "VxDev set up is complete." 
+
+exit 0

--- a/scripts/setup-vxdev.sh
+++ b/scripts/setup-vxdev.sh
@@ -52,6 +52,7 @@ sudo -v
 
 # If in an interactive session, help set up the dock
 if [[ "${DESKTOP_SESSION}" == "gnome" ]]; then
+  echo -e "\n\n"
   echo "Please install the Dash to Dock extension from Firefox. (Opening in 5 seconds.)"
   echo "Once you've done that, close Firefox to proceed."
   sleep 5

--- a/scripts/setup-vxdev.sh
+++ b/scripts/setup-vxdev.sh
@@ -2,13 +2,14 @@
 
 set -euo pipefail
 
+default_inventory="vxdev-stable"
+ansible_inventory=${1:-$default_inventory}
+
 debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
 local_user=`logname`
 local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
 vxsuite_complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
-
-ansible_inventory=$1
 
 if [[ ! -d ${vxsuite_build_system_dir}/inventories/${ansible_inventory} ]]; then
   echo "ERROR: The $ansible_inventory inventory could not be found."
@@ -51,7 +52,7 @@ sudo -v
 
 # If in an interactive session, help set up the dock
 if [[ "${DESKTOP_SESSION}" == "gnome" ]]; then
-  echo "Please install the Dash to Dock extension from Firefox."
+  echo "Please install the Dash to Dock extension from Firefox. (Opening in 5 seconds.)"
   echo "Once you've done that, close Firefox to proceed."
   sleep 5
   firefox https://extensions.gnome.org/extension/307/dash-to-dock


### PR DESCRIPTION
This PR provides a simple script interface to create a vxdev image. Because VxDev provides a full desktop environment running GNOME via Wayland, it is ideal to build an image in a VM with graphical support rather than via a console session. While you can still build a VxDev image via a console session, the dock will not be fully configured. That configuration will have to be performed once a full desktop environment is available. 