### PR TITLE
Adam/sudo timeouts

### DIFF
--- a/scripts/setup-localdev.sh
+++ b/scripts/setup-localdev.sh
@@ -38,6 +38,9 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
+# Ensure sudo credentials haven't expired
+sudo -v
+
 echo "Set up localdev tools"
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/setup_localdev.yaml
 

--- a/scripts/tb-cacvote.sh
+++ b/scripts/tb-cacvote.sh
@@ -34,6 +34,9 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
+# Ensure sudo credentials haven't expired
+sudo -v
+
 echo "Run cacvote_build playbook. This will take several minutes."
 sleep 5
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/cacvote_build.yaml

--- a/scripts/tb-clone-images.sh
+++ b/scripts/tb-clone-images.sh
@@ -33,6 +33,9 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
+# Ensure sudo credentials haven't expired
+sudo -v
+
 echo "Clone the online and offline images"
 sleep 5
 ansible-playbook -i inventories/${ansible_inventory} playbooks/virtmanager/clone-base-vm.yaml

--- a/scripts/tb-export-to-usb.sh
+++ b/scripts/tb-export-to-usb.sh
@@ -33,6 +33,9 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
+# Ensure sudo credentials haven't expired
+sudo -v
+
 echo "Export VotingWorks tools and repositories to USB"
 sleep 5
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/export_to_usb.yaml

--- a/scripts/tb-initialize-build-machine.sh
+++ b/scripts/tb-initialize-build-machine.sh
@@ -33,6 +33,9 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
+# Ensure sudo credentials haven't expired
+sudo -v
+
 echo "Install virt-manager tools"
 sleep 5
 ansible-playbook -i inventories/${ansible_inventory} playbooks/virtmanager/install-virt-manager.yaml

--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -33,6 +33,9 @@ if [[ ! -f .virtualenv/ansible/bin/activate ]]; then
   echo "Ansible installation is complete."
 fi
 
+# Ensure sudo credentials haven't expired
+sudo -v
+
 echo "Run offline_build playbook. This will take several minutes."
 sleep 5
 cd $vxsuite_build_system_dir

--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -33,9 +33,6 @@ if [[ ! -f .virtualenv/ansible/bin/activate ]]; then
   echo "Ansible installation is complete."
 fi
 
-# Ensure sudo credentials haven't expired
-sudo -v
-
 echo "Run offline_build playbook. This will take several minutes."
 sleep 5
 cd $vxsuite_build_system_dir
@@ -43,6 +40,9 @@ cd $vxsuite_build_system_dir
 if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
+
+# Ensure sudo credentials haven't expired
+sudo -v
 
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/offline_build.yaml --skip-tags online
 

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -34,6 +34,9 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
+# Ensure sudo credentials haven't expired
+sudo -v
+
 echo "Run prepare_for_build playbook. This will take several minutes."
 sleep 5
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/prepare_for_build.yaml


### PR DESCRIPTION
Rather than using Ansible's prompt for sudo credentials (which requires interaction every time a playbook is run), use `sudo -v` to revalidate sudo credentials if necessary. This should only apply if 15+ minutes have passed since the last sudo invocation, and it wasn't triggered in some way during the calling script. 