### PR TITLE
Add QA_IMAGE flag and install ffmpeg on QA images

### DIFF
--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -11,6 +11,7 @@ vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/pr
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 rust_version: "1.76.0"
+qa_image: true
 cloned_images:
   - online
   - offline

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -111,3 +111,6 @@ tpm_packages:
   - qrencode
   - tpm2-openssl
   - tpm2-tools
+
+dev_packages:
+  - ffmpeg

--- a/playbooks/install-vxsuite-packages.yaml
+++ b/playbooks/install-vxsuite-packages.yaml
@@ -72,6 +72,8 @@
       - xserver-xorg-input-all
       - xserver-xorg-video-all
       - zip
+    dev_packages:
+      - ffmpeg
 
   tasks:
     - name: Update apt cache
@@ -80,3 +82,7 @@
     - name: Install all necessary system packages
       ansible.builtin.command:
         cmd: "apt-get -y --no-install-recommends install {{ all_packages | join(' ') }}"
+    - name: Install all necessary dev packages on a qa image
+      ansible.builtin.command:
+        cmd: "apt-get -y --no-install-recommends install {{ dev_packages | join(' ') }}"
+      when: (qa_image is defined) and (qa_image is true)

--- a/playbooks/trusted_build/dev_packages.yaml
+++ b/playbooks/trusted_build/dev_packages.yaml
@@ -1,0 +1,29 @@
+---
+
+- name: Install Dev Packages on a QA Image
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+    - import_tasks: shared_tasks/user_to_configure.yaml
+    - import_tasks: shared_tasks/well_known_paths.yaml
+
+    - name: Ensure we don't carry over any packages from other tasks
+      set_fact:
+        all_packages: []
+
+    - name: Create a list of all the packages we need
+      set_fact:
+        all_packages: "{{ all_packages | default([]) + [ item ] }}"
+      with_items:
+        - "{{ dev_packages | default([]) }}"
+      when:
+        - (qa_image is defined) and (qa_image is true) and (dev_packages is defined)
+
+    - name: Import the apt role which supports online and offline builds
+      ansible.builtin.import_role:
+        name: apt
+      tags:
+        - online
+

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -5,6 +5,7 @@
   become: yes
 
 - import_playbook: packages.yaml
+- import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml

--- a/playbooks/trusted_build/prepare_for_build.yaml
+++ b/playbooks/trusted_build/prepare_for_build.yaml
@@ -5,6 +5,7 @@
   become: yes
 
 - import_playbook: packages.yaml
+- import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml


### PR DESCRIPTION
Adds the concept of a "qa_image" to the inventory definition, and installs dev-packages only for QA images. For now this is just the ffmpeg package but can be expanded in the future. In the future it would be nice if this value somehow carried through to the setup-machine script but I didn't bother with that for now. 

Tested by making and image and seeing ffmpeg installed properly, then setting the flag to false and seeing ffmpeg not installed. 