### PR TITLE
Meet VVSG2 TA TA11.1-C.3 3 logging requirement

### DIFF
--- a/playbooks/trusted_build/files/rsyslog.logrotate
+++ b/playbooks/trusted_build/files/rsyslog.logrotate
@@ -6,7 +6,7 @@
 /var/log/votingworks/cron.log
 {
 	su syslog adm
-	rotate 365
+	rotate 36500
 	daily
 	dateext
 	missingok

--- a/playbooks/trusted_build/files/vx-logs.logrotate
+++ b/playbooks/trusted_build/files/vx-logs.logrotate
@@ -1,7 +1,7 @@
 /var/log/votingworks/vx-logs.log
 {
 	su syslog adm
-	rotate 365
+	rotate 36500
 	daily
 	dateext
 	missingok


### PR DESCRIPTION
Although the VVSG2 standard states logs can be deleted as part of log rotation, the test assertions state logs cannot be deleted, even as part of log rotation.

> TA11.1-C.3 3: Log rotation MUST NOT be capable of deleting the logs. The logs MAY be saved or
archived as a separate file but cannot be removed from the system.

Deletion of older log files is a core feature of log rotation. To meet this requirement, we change our log rotation limit from 1 year to 100 years. 