### PR TITLE
[Upgrades] Node 16 -> 20, Rust 1.76 -> 1.81

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.0.0"
+  default = "4.1.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "3.0.2"
+  default = "4.0.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "3.0.2"
+  default = "4.0.0"
 }
 
 source "docker" "debian12" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.0.0"
+  default = "4.1.0"
 }
 
 source "docker" "debian12" {

--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -10,7 +10,7 @@ iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
-rust_version: "1.80.0"
+rust_version: "1.81.0"
 qa_image: true
 cloned_images:
   - online

--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -10,7 +10,7 @@ iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
-rust_version: "1.76.0"
+rust_version: "1.80.0"
 qa_image: true
 cloned_images:
   - online

--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -1,8 +1,8 @@
-node_version: "16.19.1"
+node_version: "20.16.0"
 npm_packages:
   yarn:
-    version: "1.22.15"
-    checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
+    version: "1.22.2"
+    checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.3.1"
-    checksum: "75c6e8a4075abfc494770f998bf37b9ada110f51"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/parallels-latest/group_vars/all/main.yaml
+++ b/inventories/parallels-latest/group_vars/all/main.yaml
@@ -11,4 +11,4 @@ vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/pr
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 vm_clone_name: "deb12"
-rust_version: "1.76.0"
+rust_version: "1.80.0"

--- a/inventories/parallels-latest/group_vars/all/main.yaml
+++ b/inventories/parallels-latest/group_vars/all/main.yaml
@@ -11,4 +11,4 @@ vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/pr
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 vm_clone_name: "deb12"
-rust_version: "1.80.0"
+rust_version: "1.81.0"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -1,8 +1,8 @@
-node_version: "16.19.1"
+node_version: "20.16.0"
 npm_packages:
   yarn:
-    version: "1.22.15"
-    checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
+    version: "1.22.2"
+    checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.3.1"
-    checksum: "75c6e8a4075abfc494770f998bf37b9ada110f51"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/vxdev-stable/group_vars/all/main.yaml
+++ b/inventories/vxdev-stable/group_vars/all/main.yaml
@@ -10,6 +10,6 @@ iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "vxdev-preseed.cfg"
 secure_boot: true
-rust_version: "1.80.0"
+rust_version: "1.81.0"
 cloned_images:
   - vxdev

--- a/inventories/vxdev-stable/group_vars/all/main.yaml
+++ b/inventories/vxdev-stable/group_vars/all/main.yaml
@@ -10,6 +10,6 @@ iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "vxdev-preseed.cfg"
 secure_boot: true
-rust_version: "1.76.0"
+rust_version: "1.80.0"
 cloned_images:
   - vxdev

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -1,8 +1,8 @@
-node_version: "16.19.1"
+node_version: "20.16.0"
 npm_packages:
   yarn:
-    version: "1.22.15"
-    checksum: "3431d5f134d3c752a57a9dd7f5e1167627ca3cc3"
+    version: "1.22.2"
+    checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.3.1"
-    checksum: "75c6e8a4075abfc494770f998bf37b9ada110f51"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -5,10 +5,10 @@
   become: true
 
   vars:
-    node_version: "16.19.1"
+    node_version: "20.16.0"
     npm_packages:
-      - yarn@1.22.15
-      - pnpm@8.3.1
+      - yarn@1.22.22
+      - pnpm@8.15.5
 
   tasks:
 

--- a/playbooks/install-rust.yaml
+++ b/playbooks/install-rust.yaml
@@ -5,7 +5,7 @@
   become: true
 
   vars:
-    rust_version: "1.76.0"
+    rust_version: "1.80.0"
     user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
     rustup_install_url: "https://sh.rustup.rs"
     rustup_install_cmd: "/tmp/rustup.sh"

--- a/playbooks/install-rust.yaml
+++ b/playbooks/install-rust.yaml
@@ -5,7 +5,7 @@
   become: true
 
   vars:
-    rust_version: "1.80.0"
+    rust_version: "1.81.0"
     user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
     rustup_install_url: "https://sh.rustup.rs"
     rustup_install_cmd: "/tmp/rustup.sh"


### PR DESCRIPTION
https://github.com/votingworks/vxsuite/issues/4163

Upgrading:
- Node version to `v20.16.0`
- Rust version to `v.1.81.0`
- CI Docker base image to `v4.1.0` to reflect the breaking change in dependencies