### PR TITLE
Fix online phase of build process by correcting yarn version

### DIFF
--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -1,7 +1,7 @@
 node_version: "20.16.0"
 npm_packages:
   yarn:
-    version: "1.22.2"
+    version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
     version: "8.15.5"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -1,7 +1,7 @@
 node_version: "20.16.0"
 npm_packages:
   yarn:
-    version: "1.22.2"
+    version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
     version: "8.15.5"

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -1,7 +1,7 @@
 node_version: "20.16.0"
 npm_packages:
   yarn:
-    version: "1.22.2"
+    version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
     version: "8.15.5"


### PR DESCRIPTION
Ran into the following error while building:

> "npm error code ETARGET\nnpm error notarget No matching version found for yarn@1.22.2.\nnpm error notarget In most cases you or one of your dependencies are requesting\nnpm error notarget a package version that doesn't exist.\nnpm notice\nnpm notice New patch version of npm available! 10.8.1 -> 10.8.3\nnpm notice Changelog: https://github.com/npm/cli/releases/tag/v10.8.3\nnpm notice To update run: npm install -g npm@10.8.3\nnpm notice\nnpm error A complete log of this run can be found in: /root/.npm/_logs/2024-09-24T03_16_10_144Z-debug-0.log", "stderr_lines": ["npm error code ETARGET", "npm error notarget No matching version found for yarn@1.22.2.", "npm error notarget In most cases you or one of your dependencies are requesting"

I _think_ we just recorded the wrong version - 1.22.2 instead of the correct 1.22.22. Even elsewhere in build system, we reference the correct 1.22.22:

https://github.com/votingworks/vxsuite-build-system/blob/a73bbe4b2794556b19aa654b55be44577c88429b/playbooks/install-node.yaml#L10

Confirmed that this fixes the online phase of the build process!