### PR TITLE
Add support for using updated kernel versions

### DIFF
--- a/inventories/hp-testing/group_vars/all/brother.yaml
+++ b/inventories/hp-testing/group_vars/all/brother.yaml
@@ -1,0 +1,13 @@
+---
+brother_32bit_packages:
+  - libc6:i386
+  - libncurses5:i386
+  - libstdc++6:i386
+
+brother_drivers:
+  PJ-822:
+    url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"
+    checksum: "c1fae128905bc0dbe91080fd08adc62cb2e4f7b959291d91e8294cd3f91dadf3"
+  PJ-823:
+    url: "https://download.brother.com/welcome/dlfp100952/pj823pdrv-1.2.0-1.i386.deb"
+    checksum: "933b99e2963f5642f84474a288b1e867384bda0b0440ec36a8d22e05e8478546"

--- a/inventories/hp-testing/group_vars/all/main.yaml
+++ b/inventories/hp-testing/group_vars/all/main.yaml
@@ -1,0 +1,17 @@
+repos:
+  vxsuite-complete-system:
+    version: main
+virt_image_path: "/var/lib/libvirt/images"
+vm_name: "debian-latest"
+vm_disk_size_gb: 27
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
+vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
+vm_preseed_file: "production-preseed.cfg"
+secure_boot: true
+rust_version: "1.81.0"
+qa_image: true
+cloned_images:
+  - online
+  - offline

--- a/inventories/hp-testing/group_vars/all/node.yaml
+++ b/inventories/hp-testing/group_vars/all/node.yaml
@@ -1,0 +1,8 @@
+node_version: "20.16.0"
+npm_packages:
+  yarn:
+    version: "1.22.22"
+    checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  pnpm:
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/hp-testing/group_vars/all/packages.yaml
+++ b/inventories/hp-testing/group_vars/all/packages.yaml
@@ -1,11 +1,11 @@
 ---
 batch_package_install: true
 
-#-- get the latest available kernel (if necessary)
+#-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
-#-- define here for now
 kernel_packages:
-  - linux-kbuild-6.1
+  - linux-image-6.10.*+bpo-amd64
+  - linux-kbuild-6.10
 
 all_packages:
   - alsa-utils

--- a/inventories/hp-testing/group_vars/all/packages.yaml
+++ b/inventories/hp-testing/group_vars/all/packages.yaml
@@ -4,8 +4,8 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-6.10.*+bpo-amd64
-  - linux-kbuild-6.10
+  - linux-image-amd64
+ #- linux-kbuild-6.10
 
 all_packages:
   - alsa-utils

--- a/inventories/hp-testing/group_vars/all/packages.yaml
+++ b/inventories/hp-testing/group_vars/all/packages.yaml
@@ -4,8 +4,8 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-amd64
- #- linux-kbuild-6.10
+  - linux-image-6.10.*+bpo-amd64
+  - linux-kbuild-6.10
 
 all_packages:
   - alsa-utils

--- a/inventories/hp-testing/group_vars/all/rubygems.yaml
+++ b/inventories/hp-testing/group_vars/all/rubygems.yaml
@@ -1,0 +1,4 @@
+gems:
+  fpm:
+    version: "1.15.1"
+    checksum: "1ffbf342a89ca97fb5c02e66946c97e2bd5413810f7f440ddf32f00a16052dbf"

--- a/inventories/hp-testing/hosts
+++ b/inventories/hp-testing/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -1,11 +1,11 @@
 ---
 batch_package_install: true
 
-#-- get the latest available kernel (if necessary)
+#-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
-#-- define here for now
 kernel_packages:
-  - linux-kbuild-6.1
+  - linux-image-6.10.*+bpo-amd64
+  - linux-kbuild-6.10
 
 all_packages:
   - alsa-utils

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -4,7 +4,7 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-6.10.*
+  - linux-image-6.10.*+bpo-amd64
   - linux-kbuild-6.10.*
 
 all_packages:

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -4,8 +4,8 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-amd64
-    #- linux-kbuild-6.1
+  - linux-image-6.10.*
+  - linux-kbuild-6.10.*
 
 all_packages:
   - alsa-utils

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -1,6 +1,12 @@
 ---
 batch_package_install: true
 
+#-- get the latest available kernel
+#-- kbuild needs to be tied to kernel, so probably move to the playbook
+kernel_packages:
+  - linux-image-amd64
+    #- linux-kbuild-6.1
+
 all_packages:
   - alsa-utils
   - brightnessctl
@@ -52,7 +58,6 @@ all_packages:
   - libxss1
   - libxtst6
   - libzbar-dev
-  - linux-kbuild-6.1
   - make
   - mingetty
   - openbox

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -4,8 +4,8 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-6.10.*+bpo-amd64.*
-  - linux-kbuild-6.10.*
+  - linux-image-6.10.*+bpo-amd64
+  - linux-kbuild-6.10
 
 all_packages:
   - alsa-utils

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -4,7 +4,7 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-6.10.*+bpo-amd64
+  - linux-image-6.10.*+bpo-amd64.*
   - linux-kbuild-6.10.*
 
 all_packages:

--- a/playbooks/trusted_build/export_to_usb.yaml
+++ b/playbooks/trusted_build/export_to_usb.yaml
@@ -35,6 +35,13 @@
       ansible.builtin.command: lsblk -no mountpoint "/dev/{{ device }}1"
       register: usb_mnt
     
+    - name: Ignore old electron_gyp_cache for newer Node versions
+      ansible.builtin.file:
+        path: "{{ well_known_paths['electron_gyp_cache']['system_path'] }}"
+        state: directory
+        owner: "{{ user_to_configure }}"
+        group: "{{ user_to_configure }}"
+
     #-- Ansible copy does not scale to recursive copies involving
     #-- hundreds/thousands of files, so we use rsync instead
     - name: Synchronize the files to the USB

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -55,13 +55,6 @@
       tags:
         - online
 
-    - name: Update apt sources to not include bookworm-backports
-      ansible.builtin.apt:
-        update_cache: true
-      when: apt_snapshot_date is not defined
-      tags:
-        - online
-
     - name: Install backported packages directly
       ansible.builtin.shell:
         cmd: "dpkg -i /var/cache/apt/archives/{{ item }}*deb"

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -4,6 +4,8 @@
 #      part of a VotingWorks aptly release instead of backports
 #      Probably just a block condition based on existing of aptly release?
 #
+#TODO: dont hardcode to a debian backports release, make it a config var
+#
 - name: Install an updated kernel
   hosts: 127.0.0.1
   connection: local
@@ -13,35 +15,10 @@
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
 
-    - name: Ensure we don't carry over any packages from other tasks
-      set_fact:
-        all_packages: []
-
-    - name: Create a list of all the kernel packages we need
-      set_fact:
-        all_packages: "{{ all_packages | default([]) + [ item ] }}"
-      with_items:
-        - "{{ kernel_packages | default([]) }}"
-
-    - name: De-dupe the list for efficiency
-      set_fact:
-        all_packages: "{{ all_packages | unique | select | list }}"
-
     - name: Add bookworm-backports as an apt source
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
-      tags:
-        - online
-
-    - name: Assign the highest possible priority for bookworm-backports
-      ansible.builtin.blockinfile:
-        create: true
-        path: /etc/apt/preferences.d/bookworm-backports
-        block: |
-          Package: *
-          Pin: release a=bookworm-backports
-          Pin-Priority: 999
       tags:
         - online
 
@@ -51,9 +28,19 @@
       tags:
         - online
 
-    - name: Import the apt role which supports online and offline builds
-      ansible.builtin.import_role:
-        name: apt
+    - name: Download the kernel packages
+      ansible.builtin.command:
+        cmd: "apt-get install --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports -y {{ item }}"
+      with_items:
+        - "{{ kernel_packages }}"
+      tags:
+        - online
+
+    - name: Install the packages (batch)
+      ansible.builtin.command:
+        cmd: "apt-get install -y --allow-downgrades --no-install-recommends -t bookworm-backports {{ all_packages | join(' ') }}"
+      tags:
+        - offline
 
     - name: Remove bookworm-backports as an apt source
       ansible.builtin.lineinfile:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -52,7 +52,7 @@
 
     - name: Install the packages (batch)
       ansible.builtin.command:
-        cmd: "apt-get install -y --allow-downgrades --no-install-recommends -t bookworm-backports {{ kernel_packages | join(' ') }}"
+        cmd: "apt-get install -y --allow-downgrades --no-install-recommends {{ kernel_packages | join('/bookworm-backports ') }}"
       tags:
         - offline
 

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -30,7 +30,7 @@
       ansible.builtin.command:
         cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ item }}"
       with_items:
-        - "{{ kernel_packages }}"
+        - "{{ kernel_packages | default([]) }}"
       tags:
         - online
 
@@ -54,6 +54,6 @@
       ansible.builtin.shell:
         cmd: "dpkg -i /var/cache/apt/archives/{{ item }}*deb"
       with_items:
-        - "{{ kernel_packages }}"
+        - "{{ kernel_packages | default([]) }}"
       tags:
         - offline

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -30,7 +30,7 @@
 
     - name: Download the kernel packages
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ kernel_packages }}+bpo-amd64"
+        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ kernel_packages }}"
       with_items:
         - "{{ kernel_packages }}"
       tags:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -52,7 +52,7 @@
 
     - name: Install backported packages directly
       ansible.builtin.shell:
-        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}.*deb"
+        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}.*"
       with_items:
         - "{{ kernel_packages }}"
       tags:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -11,12 +11,6 @@
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
 
-    - name: Remove unused kernel(s)
-      ansible.builtin.apt:
-        autoremove: true
-      tags:
-        - online
-
     - name: Add bookworm-backports as an apt source
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
@@ -40,6 +34,10 @@
         - "{{ kernel_packages | default([]) }}"
       tags:
         - online
+
+    - name: Remove unused kernel(s)
+      ansible.builtin.apt:
+        autoremove: true
 
     - name: Remove bookworm-backports as an apt source
       ansible.builtin.lineinfile:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -11,6 +11,10 @@
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
 
+    - name: Remove unused kernel(s)
+      ansible.builtin.command:
+        cmd: "apt autoremove"
+
     - name: Add bookworm-backports as an apt source
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
@@ -34,10 +38,6 @@
         - "{{ kernel_packages | default([]) }}"
       tags:
         - online
-
-    - name: Remove unused kernel(s)
-      ansible.builtin.apt:
-        autoremove: true
 
     - name: Remove bookworm-backports as an apt source
       ansible.builtin.lineinfile:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -30,17 +30,11 @@
 
     - name: Download the kernel packages
       ansible.builtin.command:
-        cmd: "apt-get install --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports -y {{ item }}"
+        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ kernel_packages | join(' ') }}"
       with_items:
         - "{{ kernel_packages }}"
       tags:
         - online
-
-    - name: Install the packages (batch)
-      ansible.builtin.command:
-        cmd: "apt-get install -y --allow-downgrades --no-install-recommends -t bookworm-backports {{ all_packages | join(' ') }}"
-      tags:
-        - offline
 
     - name: Remove bookworm-backports as an apt source
       ansible.builtin.lineinfile:
@@ -50,15 +44,15 @@
       tags:
         - online
 
-    - name: Delete the bookworm-backports preferences file
-      ansible.builtin.file:
-        path: /etc/apt/preferences.d/bookworm-backports
-        state: absent
-      tags:
-        - online
-
     - name: Update apt sources to remove bookworm-backports
       ansible.builtin.apt:
         update_cache: true
       tags:
         - online
+
+    - name: Install the packages (batch)
+      ansible.builtin.command:
+        cmd: "apt-get install -y --allow-downgrades --no-install-recommends -t bookworm-backports {{ kernel_packages | join(' ') }}"
+      tags:
+        - offline
+

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -28,11 +28,11 @@
         all_packages: "{{ all_packages | unique | select | list }}"
 
     - name: Add bookworm-backports as an apt source
-     ansible.builtin.lineinfile:
-       path: /etc/apt/sources.list
-       line: 'deb http://http.us.debian.org/debian bookworm-backports main'
-     tags:
-       - online
+      ansible.builtin.lineinfile:
+        path: /etc/apt/sources.list
+        line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+      tags:
+        - online
 
     - name: Assign the highest possible priority for bookworm-backports
       ansible.builtin.blockinfile:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -28,11 +28,11 @@
         all_packages: "{{ all_packages | unique | select | list }}"
 
     - name: Add bookworm-backports as an apt source
-       ansible.builtin.lineinfile:
-         path: /etc/apt/sources.list
-         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
-       tags:
-         - online
+     ansible.builtin.lineinfile:
+       path: /etc/apt/sources.list
+       line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+     tags:
+       - online
 
     - name: Assign the highest possible priority for bookworm-backports
       ansible.builtin.blockinfile:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -15,14 +15,14 @@
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
-      when: (apt_snapshot_date is defined) and (release_name is defined)
+      when: apt_snapshot_date is not defined
       tags:
         - online
 
     - name: Update apt sources to include bookworm-backports
       ansible.builtin.apt:
         update_cache: true
-      when: (apt_snapshot_date is defined) and (release_name is defined)
+      when: apt_snapshot_date is not defined
       tags:
         - online
 
@@ -39,14 +39,14 @@
         path: /etc/apt/sources.list
         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
         state: absent
-      when: (apt_snapshot_date is defined) and (release_name is defined)
+      when: apt_snapshot_date is not defined
       tags:
         - online
 
     - name: Update apt sources to remove bookworm-backports
       ansible.builtin.apt:
         update_cache: true
-      when: (apt_snapshot_date is defined) and (release_name is defined)
+      when: apt_snapshot_date is not defined
       tags:
         - online
 

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -11,6 +11,12 @@
     - import_tasks: shared_tasks/user_to_configure.yaml
     - import_tasks: shared_tasks/well_known_paths.yaml
 
+    - name: Remove unused kernel(s)
+      ansible.builtin.apt:
+        autoremove: true
+      tags:
+        - online
+
     - name: Add bookworm-backports as an apt source
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
@@ -29,7 +35,7 @@
 
     - name: Download the kernel packages
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --only-upgrade --no-install-recommends --download-only -t bookworm-backports {{ item }}"
+        cmd: "apt-get install -y --reinstall --no-install-recommends --download-only -t bookworm-backports {{ item }}"
       with_items:
         - "{{ kernel_packages | default([]) }}"
       tags:
@@ -53,7 +59,7 @@
 
     - name: Install backported packages directly
       ansible.builtin.shell:
-        cmd: "apt-get -y --no-install-recommends --only-upgrade install {{ item }}"
+        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}*deb"
       with_items:
         - "{{ kernel_packages | default([]) }}"
       tags:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -1,9 +1,5 @@
 ---
 
-#TODO: Handle a locked down release where the kernel packages are
-#      part of a VotingWorks aptly release instead of backports
-#      Probably just a block condition based on existing of aptly release?
-#
 #TODO: dont hardcode to a debian backports release, make it a config var
 #
 - name: Install an updated kernel
@@ -19,12 +15,14 @@
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+      when: (apt_snapshot_date is defined) and (release_name is defined)
       tags:
         - online
 
     - name: Update apt sources to include bookworm-backports
       ansible.builtin.apt:
         update_cache: true
+      when: (apt_snapshot_date is defined) and (release_name is defined)
       tags:
         - online
 
@@ -41,12 +39,14 @@
         path: /etc/apt/sources.list
         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
         state: absent
+      when: (apt_snapshot_date is defined) and (release_name is defined)
       tags:
         - online
 
     - name: Update apt sources to remove bookworm-backports
       ansible.builtin.apt:
         update_cache: true
+      when: (apt_snapshot_date is defined) and (release_name is defined)
       tags:
         - online
 

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -30,7 +30,7 @@
 
     - name: Download the kernel packages
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ kernel_packages }}"
+        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ item }}"
       with_items:
         - "{{ kernel_packages }}"
       tags:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -55,6 +55,13 @@
       tags:
         - online
 
+    - name: Update apt sources to not include bookworm-backports
+      ansible.builtin.apt:
+        update_cache: true
+      when: apt_snapshot_date is not defined
+      tags:
+        - online
+
     - name: Install backported packages directly
       ansible.builtin.shell:
         cmd: "dpkg -i /var/cache/apt/archives/{{ item }}*deb"

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -56,22 +56,22 @@
         name: apt
 
     - name: Remove bookworm-backports as an apt source
-       ansible.builtin.lineinfile:
-         path: /etc/apt/sources.list
-         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
-         state: absent
-       tags:
-         - online
+      ansible.builtin.lineinfile:
+        path: /etc/apt/sources.list
+        line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+        state: absent
+      tags:
+        - online
 
     - name: Delete the bookworm-backports preferences file
-       ansible.builtin.file:
-         path: /etc/apt/preferences.d/bookworm-backports
-         state: absent
-       tags:
-         - online
+      ansible.builtin.file:
+        path: /etc/apt/preferences.d/bookworm-backports
+        state: absent
+      tags:
+        - online
 
     - name: Update apt sources to remove bookworm-backports
-       ansible.builtin.apt:
-         update_cache: true
-       tags:
-         - online
+      ansible.builtin.apt:
+        update_cache: true
+      tags:
+        - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -13,7 +13,7 @@
 
     - name: Remove unused kernel(s)
       ansible.builtin.command:
-        cmd: "apt autoremove"
+        cmd: "apt -y autoremove"
 
     - name: Add bookworm-backports as an apt source
       ansible.builtin.lineinfile:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -1,6 +1,6 @@
 ---
 
-#TODO: dont hardcode to a debian backports release, make it a config var
+# TODO: install linux-kbuild based on the latest kernel installed
 #
 - name: Install an updated kernel
   hosts: 127.0.0.1
@@ -28,7 +28,7 @@
 
     - name: Download the kernel packages
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ item }}"
+        cmd: "apt-get install -y --reinstall --only-upgrade --no-install-recommends --download-only -t bookworm-backports {{ item }}"
       with_items:
         - "{{ kernel_packages | default([]) }}"
       tags:
@@ -52,7 +52,7 @@
 
     - name: Install backported packages directly
       ansible.builtin.shell:
-        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}*deb"
+        cmd: "apt-get -y --no-install-recommends --only-upgrade install {{ item }}"
       with_items:
         - "{{ kernel_packages | default([]) }}"
       tags:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -52,7 +52,7 @@
 
     - name: Install backported packages directly
       ansible.builtin.shell:
-        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}.deb"
+        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}.*deb"
       with_items:
         - "{{ kernel_packages }}"
       tags:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -1,0 +1,77 @@
+---
+
+#TODO: Handle a locked down release where the kernel packages are
+#      part of a VotingWorks aptly release instead of backports
+#      Probably just a block condition based on existing of aptly release?
+#
+- name: Install an updated kernel
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+    - import_tasks: shared_tasks/user_to_configure.yaml
+    - import_tasks: shared_tasks/well_known_paths.yaml
+
+    - name: Ensure we don't carry over any packages from other tasks
+      set_fact:
+        all_packages: []
+
+    - name: Create a list of all the kernel packages we need
+      set_fact:
+        all_packages: "{{ all_packages | default([]) + [ item ] }}"
+      with_items:
+        - "{{ kernel_packages | default([]) }}"
+
+    - name: De-dupe the list for efficiency
+      set_fact:
+        all_packages: "{{ all_packages | unique | select | list }}"
+
+    - name: Add bookworm-backports as an apt source
+       ansible.builtin.lineinfile:
+         path: /etc/apt/sources.list
+         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+       tags:
+         - online
+
+    - name: Assign the highest possible priority for bookworm-backports
+      ansible.builtin.blockinfile:
+        create: true
+        path: /etc/apt/preferences.d/bookworm-backports
+        block: |
+          Package: *
+          Pin: release a=bookworm-backports
+          Pin-Priority: 999
+      tags:
+        - online
+
+    - name: Update apt sources to include bookworm-backports
+      ansible.builtin.apt:
+        update_cache: true
+      tags:
+        - online
+
+    - name: Import the apt role which supports online and offline builds
+      ansible.builtin.import_role:
+        name: apt
+
+    - name: Remove bookworm-backports as an apt source
+       ansible.builtin.lineinfile:
+         path: /etc/apt/sources.list
+         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+         state: absent
+       tags:
+         - online
+
+    - name: Delete the bookworm-backports preferences file
+       ansible.builtin.file:
+         path: /etc/apt/preferences.d/bookworm-backports
+         state: absent
+       tags:
+         - online
+
+    - name: Update apt sources to remove bookworm-backports
+       ansible.builtin.apt:
+         update_cache: true
+       tags:
+         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -15,6 +15,7 @@
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
         line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+        insertbefore: "BOF"
       when: apt_snapshot_date is not defined
       tags:
         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -52,7 +52,7 @@
 
     - name: Install backported packages directly
       ansible.builtin.shell:
-        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}.*"
+        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}*deb"
       with_items:
         - "{{ kernel_packages }}"
       tags:

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -30,7 +30,7 @@
 
     - name: Download the kernel packages
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ kernel_packages | join(' ') }}"
+        cmd: "apt-get install -y --reinstall --allow-downgrades --no-install-recommends --download-only -t bookworm-backports {{ kernel_packages }}+bpo-amd64"
       with_items:
         - "{{ kernel_packages }}"
       tags:
@@ -50,9 +50,10 @@
       tags:
         - online
 
-    - name: Install the packages (batch)
-      ansible.builtin.command:
-        cmd: "apt-get install -y --allow-downgrades --no-install-recommends {{ kernel_packages | join('/bookworm-backports ') }}"
+    - name: Install backported packages directly
+      ansible.builtin.shell:
+        cmd: "dpkg -i /var/cache/apt/archives/{{ item }}.deb"
+      with_items:
+        - "{{ kernel_packages }}"
       tags:
         - offline
-

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -1,5 +1,9 @@
 ---
 
+# TODO: This is going to have to change with our new use of 
+#       self-hosted apt repos
+#       Figure out how to link to a specific package version 
+#       using Debian Snapshot repo?
 - name: Generate a report of COTS tools used for this build
   hosts: 127.0.0.1
   connection: local

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -4,7 +4,6 @@
   connection: local
   become: yes
 
-- import_playbook: kernel.yaml
 - import_playbook: packages.yaml
 - import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml
@@ -16,3 +15,4 @@
 - import_playbook: firewalld.yaml
 - import_playbook: logrotate.yaml
 - import_playbook: disable_services.yaml
+- import_playbook: kernel.yaml

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -4,6 +4,7 @@
   connection: local
   become: yes
 
+- import_playbook: kernel.yaml
 - import_playbook: packages.yaml
 - import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -15,4 +15,4 @@
 - import_playbook: firewalld.yaml
 - import_playbook: logrotate.yaml
 - import_playbook: disable_services.yaml
-  #- import_playbook: kernel.yaml
+- import_playbook: kernel.yaml

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -15,4 +15,4 @@
 - import_playbook: firewalld.yaml
 - import_playbook: logrotate.yaml
 - import_playbook: disable_services.yaml
-- import_playbook: kernel.yaml
+  #- import_playbook: kernel.yaml

--- a/playbooks/trusted_build/prepare_for_build.yaml
+++ b/playbooks/trusted_build/prepare_for_build.yaml
@@ -4,6 +4,7 @@
   connection: local
   become: yes
 
+- import_playbook: kernel.yaml
 - import_playbook: packages.yaml
 - import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml

--- a/playbooks/trusted_build/prepare_for_build.yaml
+++ b/playbooks/trusted_build/prepare_for_build.yaml
@@ -4,7 +4,6 @@
   connection: local
   become: yes
 
-- import_playbook: kernel.yaml
 - import_playbook: packages.yaml
 - import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml
@@ -12,3 +11,4 @@
 - import_playbook: rust.yaml
 - import_playbook: rubygems.yaml
 - import_playbook: repos.yaml
+- import_playbook: kernel.yaml

--- a/playbooks/trusted_build/prepare_for_build.yaml
+++ b/playbooks/trusted_build/prepare_for_build.yaml
@@ -11,4 +11,3 @@
 - import_playbook: rust.yaml
 - import_playbook: rubygems.yaml
 - import_playbook: repos.yaml
-- import_playbook: kernel.yaml

--- a/playbooks/trusted_build/shared_tasks/well_known_paths.yaml
+++ b/playbooks/trusted_build/shared_tasks/well_known_paths.yaml
@@ -6,6 +6,9 @@
       apt_packages:
         system_path: "/var/cache/apt/archives"
         usb_path: "apt_packages"
+      apt_lists:
+        system_path: "/var/lib/apt/lists"
+        usb_path: "apt_lists"
       pnpm_packages:
         system_path: "~{{ user_to_configure }}/.local/share/pnpm"
         usb_path: "pnpm_packages"

--- a/roles/apt/tasks/main.yaml
+++ b/roles/apt/tasks/main.yaml
@@ -4,6 +4,8 @@
   ansible.builtin.apt:
     update_cache: yes
     cache_valid_time: 3600
+  tags:
+    - online
 
 - name: Create apt preference config (if necessary)
   ansible.builtin.template:

--- a/scripts/tb-import-from-usb.sh
+++ b/scripts/tb-import-from-usb.sh
@@ -84,8 +84,10 @@ if [ ! -d $electron_gyp_dir ]; then
   mkdir -p $electron_gyp_dir
   chown -R ${local_user}:${local_user} $electron_gyp_dir
 fi
-cp -r ${usb_root}/electron_gyp_cache/* $electron_gyp_dir
-chown -R ${local_user}:${local_user} $electron_gyp_dir
+if [ -d ${usb_root}/electron_gyp_cache ]; then
+  cp -r ${usb_root}/electron_gyp_cache/* $electron_gyp_dir
+  chown -R ${local_user}:${local_user} $electron_gyp_dir
+fi
 
 #-- Copy yarn cache
 echo "Copying yarn cache"

--- a/scripts/tb-import-from-usb.sh
+++ b/scripts/tb-import-from-usb.sh
@@ -37,6 +37,10 @@ cp -r ${usb_root}/downloads /var/tmp/
 #-- Copy all the apt packages to the local cache
 echo "Copying apt packages to local cache"
 cp -r ${usb_root}/apt_packages/* /var/cache/apt/archives/
+#
+#-- Copy all the apt lists to the local system
+echo "Copying apt lists to local system"
+cp -r ${usb_root}/apt_lists/* /var/lib/apt/lists/
 
 if [ ! -d $code_dir ]; then
   mkdir -p $code_dir

--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -53,8 +53,8 @@ make offline-kiosk-browser
 
 echo "Run build.sh in complete-system. This will take several minutes."
 sleep 5
-#cd $vxsuite_complete_system_dir
-#./build.sh
+cd $vxsuite_complete_system_dir
+./build.sh
 
 echo "The offline build phase is complete."
 echo "Depending on your needs, clone this VM and run setup-machine OR"

--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -53,8 +53,8 @@ make offline-kiosk-browser
 
 echo "Run build.sh in complete-system. This will take several minutes."
 sleep 5
-cd $vxsuite_complete_system_dir
-./build.sh
+#cd $vxsuite_complete_system_dir
+#./build.sh
 
 echo "The offline build phase is complete."
 echo "Depending on your needs, clone this VM and run setup-machine OR"

--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -56,6 +56,10 @@ sleep 5
 cd $vxsuite_complete_system_dir
 ./build.sh
 
+# Node20 upgrade has modified the permissions on some cached build dirs
+# Reset them so they can later be deleted during final image creation
+sudo chown -R ${local_user}:${local_user} ${local_user_home_dir}/.*
+
 echo "The offline build phase is complete."
 echo "Depending on your needs, clone this VM and run setup-machine OR"
 echo "run setup-machine in this VM, understanding it is destructive."

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -38,7 +38,7 @@ fi
 sudo -v
 
 # Don't install the kernel in the online phase
-#ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/kernel.yaml --skip-tags offline
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/kernel.yaml --skip-tags offline
 
 echo "Run prepare_for_build playbook. This will take several minutes."
 sleep 5

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -51,8 +51,8 @@ fi
 
 echo "Run prepare_build.sh in complete-system. This will take several minutes."
 sleep 5
-#cd $vxsuite_complete_system_dir
-#./prepare_build.sh
+cd $vxsuite_complete_system_dir
+./prepare_build.sh
 
 echo "Download necessary tools for TPM."
 sleep 5

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -38,7 +38,7 @@ fi
 sudo -v
 
 # Don't install the kernel in the online phase
-ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/kernel.yaml --skip-tags offline
+#ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/kernel.yaml --skip-tags offline
 
 echo "Run prepare_for_build playbook. This will take several minutes."
 sleep 5

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -61,6 +61,9 @@ sleep 5
 cd $vxsuite_build_system_dir
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/brother_printers.yaml --skip-tags offline
 
+# Don't install the kernel in the online phase
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/kernel.yaml --skip-tags offline
+
 echo "The online phase is complete. Please insert a USB drive and run: "
 echo "./scripts/tb-export-to-usb.sh ${ansible_inventory}"
 

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -37,6 +37,9 @@ fi
 # Ensure sudo credentials haven't expired
 sudo -v
 
+# Don't install the kernel in the online phase
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/kernel.yaml --skip-tags offline
+
 echo "Run prepare_for_build playbook. This will take several minutes."
 sleep 5
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/prepare_for_build.yaml
@@ -61,8 +64,6 @@ sleep 5
 cd $vxsuite_build_system_dir
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/brother_printers.yaml --skip-tags offline
 
-# Don't install the kernel in the online phase
-ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/kernel.yaml --skip-tags offline
 
 echo "The online phase is complete. Please insert a USB drive and run: "
 echo "./scripts/tb-export-to-usb.sh ${ansible_inventory}"

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -48,8 +48,8 @@ fi
 
 echo "Run prepare_build.sh in complete-system. This will take several minutes."
 sleep 5
-cd $vxsuite_complete_system_dir
-./prepare_build.sh
+#cd $vxsuite_complete_system_dir
+#./prepare_build.sh
 
 echo "Download necessary tools for TPM."
 sleep 5


### PR DESCRIPTION
Because Debian focuses on stability, the kernel version lags behind more recent updates. Our new HP laptops require an updated kernel version to enable things like trackpad support, graphics modules, and more. This PR takes advantage of the Debian `backports` repo where more recent versions of packages are available while still being reasonably tested.

During the online phase of a build, the `bookworm-backports` repo is enabled and apt updated. The kernel packages are downloaded but not installed. After being downloaded, the `bookworm-backports` repo is disabled and apt updated once again. This is done so that we only obtain kernel packages from the backports repo. All other packages from the stable repos.

Once the online phase completes, the complete state of the apt repos is included in the usb transfer to the offline build. This ensures a consistent state for the offline package build since that VM cannot run `apt update` commands. Without this state, dependencies will be out of sync and the build will fail. The kernel packages are installed directly (using `dpkg`) during the offline phase rather than via `apt` since we do not include the `bookworm-backports` apt repo in this phase.

This PR also corrects some minor issues introduced in the Trusted Build process related to the Node 20 upgrade. One of the electron cache directories no longer exists so the transfer was failing, and several directories now have permissions that prevented our final cleanup steps when creating final images. Both of these issues are resolved. 

As usual, leaving the Ansible inventory that was used for the majority of this work. It will be removed in a future PR.