### PR TITLE
Move fipsmodule.cnf to /vx/config

### DIFF
--- a/inventories/v4.0.0/group_vars/all/main.yaml
+++ b/inventories/v4.0.0/group_vars/all/main.yaml
@@ -1,6 +1,6 @@
 repos:
   vxsuite-complete-system:
-    version: v4.0.0-beta
+    version: v4.0.0-rc1
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-v4.0.0"
 vm_disk_size_gb: 27

--- a/playbooks/trusted_build/files/openssl-3.0.9.cnf
+++ b/playbooks/trusted_build/files/openssl-3.0.9.cnf
@@ -48,7 +48,7 @@ tsa_policy3 = 1.2.3.4.5.7
 # fips provider. It contains a named section e.g. [fips_sect] which is
 # referenced from the [provider_sect] below.
 # Refer to the OpenSSL security policy for more information.
-.include /usr/local/ssl/fipsmodule.cnf
+.include /vx/config/fipsmodule.cnf
 
 [openssl_init]
 providers = provider_sect


### PR DESCRIPTION
Since /usr can't be written to on locked-down images and this file has to be dynamically updated by the configuration wizard. Pairs with https://github.com/votingworks/vxsuite-complete-system/pull/420/commits/83a0b53b574c532c05e4ece0fa40a2ba1bd98842