### PR TITLE
Add v4.0.1 inventory (copy of v4.0.0 with an edit to the vxsuite-complete-system tag)

### DIFF
--- a/inventories/v4.0.1/group_vars/all/brother.yaml
+++ b/inventories/v4.0.1/group_vars/all/brother.yaml
@@ -1,0 +1,13 @@
+---
+brother_32bit_packages:
+  - libc6:i386
+  - libncurses5:i386
+  - libstdc++6:i386
+
+brother_drivers:
+  PJ-822:
+    url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"
+    checksum: "c1fae128905bc0dbe91080fd08adc62cb2e4f7b959291d91e8294cd3f91dadf3"
+  PJ-823:
+    url: "https://download.brother.com/welcome/dlfp100952/pj823pdrv-1.2.0-1.i386.deb"
+    checksum: "933b99e2963f5642f84474a288b1e867384bda0b0440ec36a8d22e05e8478546"

--- a/inventories/v4.0.1/group_vars/all/main.yaml
+++ b/inventories/v4.0.1/group_vars/all/main.yaml
@@ -1,0 +1,16 @@
+repos:
+  vxsuite-complete-system:
+    version: v4.0.0-rc2
+virt_image_path: "/var/lib/libvirt/images"
+vm_name: "debian-v4.0.0"
+vm_disk_size_gb: 27
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
+vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
+vm_preseed_file: "production-preseed.cfg"
+secure_boot: true
+rust_version: "1.81.0"
+cloned_images:
+  - online
+  - offline

--- a/inventories/v4.0.1/group_vars/all/main.yaml
+++ b/inventories/v4.0.1/group_vars/all/main.yaml
@@ -1,8 +1,8 @@
 repos:
   vxsuite-complete-system:
-    version: v4.0.0-rc2
+    version: v4.0.1-rc1
 virt_image_path: "/var/lib/libvirt/images"
-vm_name: "debian-v4.0.0"
+vm_name: "debian-v4.0.1"
 vm_disk_size_gb: 27
 iso_version: "12.2.0"
 iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"

--- a/inventories/v4.0.1/group_vars/all/node.yaml
+++ b/inventories/v4.0.1/group_vars/all/node.yaml
@@ -1,0 +1,8 @@
+node_version: "20.16.0"
+npm_packages:
+  yarn:
+    version: "1.22.22"
+    checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  pnpm:
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/v4.0.1/group_vars/all/packages.yaml
+++ b/inventories/v4.0.1/group_vars/all/packages.yaml
@@ -1,0 +1,125 @@
+---
+batch_package_install: true
+apt_snapshot_date: "20241030"
+release_name: "bookworm"
+
+#-- get the latest available kernel
+#-- kbuild needs to be tied to kernel, so probably move to the playbook
+kernel_packages:
+  - linux-image-6.10.*+bpo-amd64
+  - linux-kbuild-6.10
+
+all_packages:
+  - alsa-utils
+  - brightnessctl
+  - build-essential
+  - chromium
+  - cloud-guest-utils
+  - cryptsetup
+  - cups
+  - cups-bsd
+  - cups-client
+  - curl
+  - default-jdk
+  - dosfstools
+  - efitools
+  - exfatprogs
+  - fdisk
+  - firewalld
+  - firmware-linux-free
+  - firmware-misc-nonfree
+  - firmware-sof-signed
+  - fonts-wqy-zenhei
+  - git
+  - gvfs
+  - gzip
+  - hplip
+  - ipp-usb
+  - iptables
+  - jq
+  - kde-cli-tools
+  - libatspi2.0-0
+  - libcairo2-dev
+  - libgif-dev
+  - libglib2.0-bin
+  - libgtk-3-0
+  - libjpeg-dev
+  - libnotify4
+  - libpango1.0-dev
+  - libpcsclite1
+  - libpcsclite-dev
+  - libpixman-1-dev
+  - libpng-dev
+  - libsane
+  - libsane1
+  - libsane-common
+  - libsane-hpaio
+  - libudev-dev
+  - libusb-1.0-0-dev
+  - libx11-dev
+  - libxss1
+  - libxtst6
+  - libzbar-dev
+  - make
+  - mingetty
+  - openbox
+  - parted
+  - pcscd
+  - pcsc-tools
+  - pulseaudio
+  - pulseaudio-utils
+  - rsync
+  - rsyslog
+  - ruby
+  - ruby-dev
+  - sane-airscan
+  - sane-utils
+  - sbsigntool
+  - swig
+  - systemd-boot-efi
+  - tar
+  - trash-cli
+  - unclutter
+  - unzip
+  - wget
+  - x11-common
+  - xdg-utils
+  - xinit
+  - xinput
+  - xorg
+  - xserver-xorg-core
+  - xserver-xorg-input-all
+  - xserver-xorg-input-libinput
+  - xserver-xorg-input-wacom
+  - xserver-xorg-video-all
+  - zip
+
+tpm_packages:
+  - autoconf
+  - autoconf-archive
+  - automake
+  - autotools-dev
+  - libcurl4-openssl-dev
+  - libjson-c-dev
+  - libltdl-dev
+  - libqrencode4
+  - libqrencode-dev
+  - libssl-dev
+  - libtool
+  - libtss2-esys-3.0.2-0
+  - libtss2-fapi1
+  - libtss2-mu0
+  - libtss2-rc0
+  - libtss2-sys1
+  - libtss2-tcti-cmd0
+  - libtss2-tcti-device0
+  - libtss2-tctildr0
+  - libtss2-tcti-mssim0
+  - libtss2-tcti-swtpm0
+  - m4
+  - qrencode
+  - tpm2-openssl
+  - tpm2-tools
+
+dev_packages:
+  - ffmpeg

--- a/inventories/v4.0.1/group_vars/all/rubygems.yaml
+++ b/inventories/v4.0.1/group_vars/all/rubygems.yaml
@@ -1,0 +1,4 @@
+gems:
+  fpm:
+    version: "1.15.1"
+    checksum: "1ffbf342a89ca97fb5c02e66946c97e2bd5413810f7f440ddf32f00a16052dbf"

--- a/inventories/v4.0.1/hosts
+++ b/inventories/v4.0.1/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local


### PR DESCRIPTION
This PR sets up a new inventory for v4.0.1! The inventory is a copy of the v4.0.0 inventory, with an edit to the vxsuite-complete-system tag.

```
$ cd ~/code/vxsuite-build-system
$ diff -r inventories/v4.0.0 inventories/v4.0.1
diff -r inventories/v4.0.0/group_vars/all/main.yaml inventories/v4.0.1/group_vars/all/main.yaml
3c3
<     version: v4.0.0-rc2
---
>     version: v4.0.1-rc1
5c5
< vm_name: "debian-v4.0.0"
---
> vm_name: "debian-v4.0.1"
```

As you can see in the commit history, I started by just copying the v4.0.0 inventory.