### PR TITLE
Update the COTS Report playbook to support VxWorks self-hosted repos

### DIFF
--- a/docs/fixing-broken-cots-report.md
+++ b/docs/fixing-broken-cots-report.md
@@ -1,0 +1,20 @@
+When using public Debian repos, there can be multiple high-level repos, e.g. `main`, `non-free-firmware`. Now that we are using VxWorks self-hosted repos, we create a single `main` repo with all packages contained within it, regardless of their public source. As a result, this can cause our COTS report playbook to generate broken links for packages originally located outside of `main`. 
+
+After generating a COTS report, you can run the [scripts/tb-validate-cots-report.sh](https://github.com/votingworks/vxsuite-build-system/blob/main/scripts/tb-validate-cots-report.sh) script. It will notify you of any broken links within the report. At this time, manual intervention is required to fix these links.
+
+As an example, we will use a sample broken link for the `firmware-sof-signed` package.
+```
+http://snapshot.debian.org/archive/debian/20241031T212645Z/pool/main/f/firmware-sof/firmware-sof-signed_2.2.4-1_all.deb = 404
+```
+
+The first step is to look this package up on snapshot.debian.org and determine the correct "pool" to use. 
+
+1. Navigate to [snapshot.debian.org](https://snapshot.debian.org)
+2. Search for the package name (no versions) using the "Search for a binary package name" input field. In our example, you would search for `firmware-sof-signed`
+3. On the results page, find the specific version and select it. In this example: `2.2.4-1`
+4. In the `Binary packages` section, you will see references to the package, along with information about where the package is available. You're looking for something like "Seen in debian on 2023-01-21 21:34:39 in /pool/non-free-firmware/f/firmware-sof."
+5. Make note of the value immediately after `/pool/`. That is what you need to modify in the COTS report. In our example, that value is `non-free-firmware`, so you would change `main` to `non-free-firmware`. Everything else should remain the same. The updated link would be:
+```
+http://snapshot.debian.org/archive/debian/20241031T212645Z/pool/non-free-firmware/f/firmware-sof/firmware-sof-signed_2.2.4-1_all.deb
+```
+6. After updating all broken links, you should run the validation script again to verify all links are now valid. Once they are, your COTS report should be ready for further use. 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -1,9 +1,5 @@
 ---
 
-# TODO: This is going to have to change with our new use of 
-#       self-hosted apt repos
-#       Figure out how to link to a specific package version 
-#       using Debian Snapshot repo?
 - name: Generate a report of COTS tools used for this build
   hosts: 127.0.0.1
   connection: local
@@ -109,7 +105,7 @@
     - name: Get the filename in the apt repo
       ansible.builtin.shell:
         cmd: >
-          apt-cache show {{ item }} | grep "Filename" | 
+          apt-cache show {{ item }} | grep "Filename:" | 
           cut -d' ' -f2
       loop: "{{ deduped_packages }}"
       register: apt_filenames
@@ -117,14 +113,22 @@
     - name: Get the SHA256 hash
       ansible.builtin.shell:
         cmd: >
-          apt-cache show {{ item }} | grep "SHA256" | 
+          apt-cache show {{ item }} | grep "SHA256:" | 
           cut -d' ' -f2
       loop: "{{ deduped_packages }}"
       register: apt_checksums
 
+    - name: Get the version
+      ansible.builtin.shell:
+        cmd: >
+          apt-cache show {{ item }} | grep "Version:" | 
+          cut -d' ' -f2
+      loop: "{{ deduped_packages }}"
+      register: apt_versions
+
     - name: Print COTS for apt packages
       ansible.builtin.shell:
         cmd: >
-          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.0 | split('=') | last }},,{{ item.2.stdout }}" >> {{ cots_csv_file }}
-      loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results) | list }}"
+          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.3.stdout }},,{{ item.2.stdout }}" >> {{ cots_csv_file }}
+      loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results, apt_versions.results) | list }}"
 

--- a/playbooks/trusted_build/misc_tasks/cots_report.yaml
+++ b/playbooks/trusted_build/misc_tasks/cots_report.yaml
@@ -1,5 +1,11 @@
 ---
 
+# TODO: we only have one repo (main) in our self-hosted setup
+#       some packages come from other repos, e.g. non-free-firmware
+#       The snapshot.debian.org url for those packages will be generated
+#       with "main" rather than the appropriate repo, resulting in a broken
+#       link. Need to figure out how to handle this.
+
 - name: Generate a report of COTS tools used for this build
   hosts: 127.0.0.1
   connection: local
@@ -87,9 +93,18 @@
 
     # Apt packages versions and checksums
     #
+    # Due to how packages are archived to Debian snapshots
+    # we need to use a date two days in the future to handle
+    # edge cases in which a package is archived after our self-hosted
+    # repo is created
+    - name: Set the snapshot date to use with Debian's snapshots
+      ansible.builtin.shell:
+        cmd: date -d "{{ apt_snapshot_date }} + 2 days" +%Y%m%d
+      register: debian_snapshot_date
+
     - name: Set the apt repo URL
       ansible.builtin.uri:
-        url: "https://snapshot.debian.org/archive/debian/{{ apt_snapshot_date }}"
+        url: "https://snapshot.debian.org/archive/debian/{{ debian_snapshot_date.stdout }}"
         return_content: no
         follow_redirects: all
       register: apt_url
@@ -126,9 +141,11 @@
       loop: "{{ deduped_packages }}"
       register: apt_versions
 
+    # The regex_replace filter is necessary to remove a Debian versioning
+    # convention that is not used in snapshot.debian.org package names
     - name: Print COTS for apt packages
       ansible.builtin.shell:
         cmd: >
-          echo "{{ apt_url.url }}{{ item.1.stdout }},{{ item.1.stdout | split('/') | last }},{{ item.3.stdout }},,{{ item.2.stdout }}" >> {{ cots_csv_file }}
+          echo "{{ apt_url.url }}{{ item.1.stdout | regex_replace('\d+%3a', '') }},{{ item.1.stdout | split('/') | last }},{{ item.3.stdout }},,{{ item.2.stdout }}" >> {{ cots_csv_file }}
       loop: "{{ deduped_packages | zip(apt_filenames.results, apt_checksums.results, apt_versions.results) | list }}"
 

--- a/scripts/tb-validate-cots-report.sh
+++ b/scripts/tb-validate-cots-report.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This is a convenience script meant to identify broken links in a
+# Trusted Build release COTS report. The identified links currently 
+# require a manual fix.
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 /path/to/cots_report.csv"
+  exit 1
+fi
+
+cots_report=$1
+
+if [[ ! -f ${cots_report} ]]; then
+  echo "Error: ${cots_report} could not be found. Please verify the path."
+  exit 2
+fi
+
+tmp_cots_get="/tmp/cots_get.log"
+
+if [[ -f ${tmp_cots_get} ]]; then
+  rm -f ${tmp_cots_get}
+fi
+
+echo "Validating current links in ${cots_report}..."
+for url in `cut -d',' -f1 ${cots_report}`
+do
+  echo -n "$url = " >> ${tmp_cots_get}
+  curl -s -L -I -o /dev/null -w "%{http_code}" "${url}" >> ${tmp_cots_get}
+  echo "" >> ${tmp_cots_get}
+done
+
+grep 404 ${tmp_cots_get}
+if [[ $? == "0" ]];
+then
+  echo ""
+  echo "You will need to manually fix these links in ${cots_report}"
+else
+  echo ""
+  echo "No broken links were found. ${cots_report} can be included in the SLI spreadsheet."
+fi
+
+exit 0;


### PR DESCRIPTION
We have switched from using snapshot.debian.org to VxWorks self-hosted apt repos. That switch required an update to the playbook that generates our COTS report for SLI. Since we must refer to publicly available versions of tools not hosted by VxWorks, we are still using snapshot.debian.org as the public location for apt packages to be found.

To support this change, the following changes were necessary:
* Rather than using the `apt_snapshot_date`, we use `apt_snapshot_date + 2 days`. This is necessary due to how Debian packages are archived to snapshot repos to ensure we account for edge cases in which a package is archived after our self-hosted repo has been set up. 
* Some Debian packages use a modified version/naming scheme that includes a leading `epoch` value, e.g. `2:1-2-3` as opposed to the standard version scheme of `1-2-3`. This `epoch` value is not included in snapshot.debian.org urls, so the playbook now removes those when creating the final url for each package.

Note: This PR also includes a validation script for the COTS report due to how VxWorks self-hosted repos differ from public Debian repos. You can find more information about that process in [docs/fixing-broken-cots-report.md](https://github.com/votingworks/vxsuite-build-system/blob/bf7993bcb66639e0777421dcc6cab8bbaba02ac9/docs/fixing-broken-cots-report.md)