### PR TITLE
build(docker): bump CI image versions for Rust 1.86.0

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.1.0"
+  default = "4.2.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.1.0"
+  default = "4.2.0"
 }
 
 source "docker" "debian12" {


### PR DESCRIPTION
Follow up to #154 