### PR TITLE
bump latest kernel version

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -4,8 +4,8 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-6.10.*+bpo-amd64
-  - linux-kbuild-6.10
+  - linux-image-6.12.*+bpo-amd64
+  - linux-kbuild-6.12
 
 all_packages:
   - alsa-utils


### PR DESCRIPTION
Latest kernel has moved from 6.10 to 6.12, so this updates the latest inventory to reflect it.