### PR TITLE
Add support required for new AMD+Radeon hardware

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -24,6 +24,8 @@ all_packages:
   - exfatprogs
   - fdisk
   - firewalld
+  - firmware-amd-graphics
+  - firmware-linux
   - firmware-linux-free
   - firmware-misc-nonfree
   - firmware-sof-signed

--- a/inventories/vxdev-stable/group_vars/all/packages.yaml
+++ b/inventories/vxdev-stable/group_vars/all/packages.yaml
@@ -4,8 +4,8 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-6.10.*+bpo-amd64
-  - linux-kbuild-6.10
+  - linux-image-6.12.*+bpo-amd64
+  - linux-kbuild-6.12
 
 all_packages:
   - alsa-utils
@@ -24,7 +24,9 @@ all_packages:
   - exfatprogs
   - fdisk
   - firewalld
+  - firmware-amd-graphics
   - firmware-iwlwifi
+  - firmware-linux
   - firmware-linux-free
   - firmware-misc-nonfree
   - firmware-realtek

--- a/inventories/vxpollbook-latest/group_vars/all/packages.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/packages.yaml
@@ -4,8 +4,8 @@ batch_package_install: true
 #-- get the latest available kernel
 #-- kbuild needs to be tied to kernel, so probably move to the playbook
 kernel_packages:
-  - linux-image-6.10.*+bpo-amd64
-  - linux-kbuild-6.10
+  - linux-image-6.12.*+bpo-amd64
+  - linux-kbuild-6.12
 
 all_packages:
   - alsa-utils
@@ -24,7 +24,9 @@ all_packages:
   - exfatprogs
   - fdisk
   - firewalld
+  - firmware-amd-graphics
   - firmware-iwlwifi
+  - firmware-linux
   - firmware-linux-free
   - firmware-misc-nonfree
   - firmware-realtek

--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -196,6 +196,12 @@ sudo ln -sf /var/vx/config /vx/config
 
 sudo ln -s /vx/code/config/read-vx-machine-config.sh /vx/config/read-vx-machine-config.sh
 
+# To support new images installed via older vx-iso releases
+# explicitly set the EXPAND_VAR flag file
+# (This gets set by new vx-iso releases, so we can eventually remove
+# setting the flag here, but it doesn't hurt to leave it)
+sudo touch /vx/config/EXPAND_VAR
+
 # machine manufacturer
 sudo sh -c 'echo "VotingWorks" > /vx/config/machine-manufacturer'
 


### PR DESCRIPTION
This PR bumps kernel versions to the latest `6.12` release and adds necessary packages to support the AMD+Radeon laptop we're planning to use.