### PR TITLE
Update vxpollbook build process after it was migrated to vxsuite

### DIFF
--- a/inventories/vxpollbook-latest/group_vars/all/main.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/main.yaml
@@ -1,7 +1,7 @@
 repos:
   kiosk-browser:
     version: main
-  vxpollbook:
+  vxsuite:
     version: main
   vxsuite-complete-system:
     version: caro/vxpollbook

--- a/inventories/vxpollbook-latest/group_vars/all/main.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/main.yaml
@@ -4,7 +4,7 @@ repos:
   vxsuite:
     version: main
   vxsuite-complete-system:
-    version: adam/pollbook-update
+    version: main
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian12-2-pollbook-base"
 vm_disk_size_gb: 35

--- a/inventories/vxpollbook-latest/group_vars/all/main.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/main.yaml
@@ -4,7 +4,7 @@ repos:
   vxsuite:
     version: main
   vxsuite-complete-system:
-    version: caro/vxpollbook
+    version: adam/pollbook-update
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian12-2-pollbook-base"
 vm_disk_size_gb: 35

--- a/inventories/vxpollbook-latest/group_vars/all/packages.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/packages.yaml
@@ -65,6 +65,7 @@ all_packages:
   - make
   - mingetty
   - openbox
+  - pahole
   - parted
   - pcscd
   - pcsc-tools

--- a/inventories/vxpollbook-latest/group_vars/all/packages.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/packages.yaml
@@ -100,3 +100,31 @@ all_packages:
   - strongswan
   - avahi-autoipd
   - iw
+
+tpm_packages:
+  - autoconf
+  - autoconf-archive
+  - automake
+  - autotools-dev
+  - libcurl4-openssl-dev
+  - libjson-c-dev
+  - libltdl-dev
+  - libqrencode4
+  - libqrencode-dev
+  - libssl-dev
+  - libtool
+  - libtss2-esys-3.0.2-0
+  - libtss2-fapi1
+  - libtss2-mu0
+  - libtss2-rc0
+  - libtss2-sys1
+  - libtss2-tcti-cmd0
+  - libtss2-tcti-device0
+  - libtss2-tctildr0
+  - libtss2-tcti-mssim0
+  - libtss2-tcti-swtpm0
+  - m4
+  - qrencode
+  - tpm2-openssl
+  - tpm2-tools
+

--- a/inventories/vxpollbook-latest/group_vars/all/rust.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/rust.yaml
@@ -1,3 +1,3 @@
-rust_version: "1.76.0"
+rust_version: "1.86.0"
 targets_to_add:
   - wasm32-unknown-unknown

--- a/playbooks/trusted_build/pollbook_build.yaml
+++ b/playbooks/trusted_build/pollbook_build.yaml
@@ -13,4 +13,6 @@
 - import_playbook: pollbook_label_printer.yaml
 - import_playbook: brother_printers.yaml
 - import_playbook: logrotate.yaml
+- import_playbook: tpm.yaml
+- import_playbook: openssl_fips.yaml
 - import_playbook: kernel.yaml

--- a/scripts/pollbook-files/run-vxpollbook.sh
+++ b/scripts/pollbook-files/run-vxpollbook.sh
@@ -17,4 +17,4 @@ fi
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxpollbook/backend run & make -C vxpollbook/frontend run) | logger -S 4096 --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxpollbook/apps/pollbook/backend run & make -C vxpollbook/apps/pollbook/frontend run) | logger -S 4096 --tag votingworksapp

--- a/scripts/pollbook-files/sudoers-for-dev
+++ b/scripts/pollbook-files/sudoers-for-dev
@@ -22,6 +22,7 @@ vx-vendor	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/set-clock.sh
+vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/choose-vx-machine-id.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/rekey-via-tpm.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/expand-var-filesystem.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/lockdown.sh

--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -8,7 +8,8 @@ local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
 kiosk_browser_dir="${local_user_home_dir}/code/kiosk-browser"
 complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
-pollbook_dir="${local_user_home_dir}/code/vxsuite/apps/pollbook"
+vxsuite_dir="${local_user_home_dir}/code/vxsuite"
+pollbook_dir="${vxsuite_dir}/apps/pollbook"
 
 ansible_inventory='vxpollbook-latest'
 
@@ -78,6 +79,15 @@ set +e
       "${complete_system_dir}/app-scripts" \
       "${complete_system_dir}/setup-scripts/setup-logging.sh" \
       "${BUILD_ROOT}"
+
+    # TODO: Understand why this is necessary
+    # The BUILD_ROOT output does not include fixtures/data
+    # so we copy it over from the original build within vxsuite
+    # A similar workaround is present for other vxsuite apps
+    # but since we build them all at once with a slightly different
+    # approach, a symlink to the entire vxsuite build is used
+    rm -rf "${BUILD_ROOT}/vxpollbook/libs/fixtures"
+    cp -rp "${vxsuite_dir}/libs/fixtures" "${BUILD_ROOT}/vxpollbook/libs/"
   )
 
 exit 0

--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -8,7 +8,7 @@ local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
 kiosk_browser_dir="${local_user_home_dir}/code/kiosk-browser"
 complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
-pollbook_dir="${local_user_home_dir}/code/vxsuite/apps/pollbooks"
+pollbook_dir="${local_user_home_dir}/code/vxsuite/apps/pollbook"
 
 ansible_inventory='vxpollbook-latest'
 

--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -57,6 +57,8 @@ sudo dpkg -i dist/kiosk-browser_1.0.0_*.deb
 
 echo "Build VxPollbook"
 sleep 5
+# Make sure cargo is available in case it hasn't been sourced yet
+export PATH="${local_user_home_dir}/.cargo/bin:${PATH}"
 cd $pollbook_dir
 pnpm install
 export BUILD_ROOT="${local_user_home_dir}/build"

--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -8,7 +8,7 @@ local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"
 kiosk_browser_dir="${local_user_home_dir}/code/kiosk-browser"
 complete_system_dir="${local_user_home_dir}/code/vxsuite-complete-system"
-pollbook_dir="${local_user_home_dir}/code/vxpollbook"
+pollbook_dir="${local_user_home_dir}/code/vxsuite/apps/pollbooks"
 
 ansible_inventory='vxpollbook-latest'
 

--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -207,7 +207,7 @@ sudo sh -c 'echo "VotingWorks" > /vx/config/machine-manufacturer'
 
 # machine model name i.e. "VxScan"
 sudo -E sh -c 'echo "VxPollbook" > /vx/config/machine-model-name'
-sudo -E sh -c 'echo "pollbook" > /vx/config/machine-type'
+sudo -E sh -c 'echo "poll-book" > /vx/config/machine-type'
 
 # code version, e.g. "2021.03.29-d34db33fcd"
 GIT_HASH=$(git rev-parse HEAD | cut -c -10) sudo -E sh -c 'echo "$(date +%Y.%m.%d)-${GIT_HASH}" > /vx/code/code-version'

--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -166,6 +166,9 @@ sudo mv $build_dir /vx/code
 sudo ln -s /vx/code/vxpollbook /vx/services/vxpollbook
 sudo ln -s /vx/code/run-vxpollbook.sh /vx/services/run-vxpollbook.sh
 
+# symlink to vxsuite so paths dont break
+sudo ln -s /vx/code/vxpollbook /vx/code/vxsuite
+
 # symlink appropriate vx/ui files
 sudo ln -s /vx/code/config/ui_bash_profile /vx/ui/.bash_profile
 sudo ln -s /vx/code/config/Xresources /vx/ui/.Xresources

--- a/scripts/tb-clone-images.sh
+++ b/scripts/tb-clone-images.sh
@@ -36,7 +36,7 @@ fi
 # Ensure sudo credentials haven't expired
 sudo -v
 
-echo "Clone the online and offline images"
+echo "Clone image(s)"
 sleep 5
 ansible-playbook -i inventories/${ansible_inventory} playbooks/virtmanager/clone-base-vm.yaml
 


### PR DESCRIPTION
This PR updates the build process for vxpollbook now that it is included in vxsuite rather than existing as a separate repo. Most of these changes were updates to pathing and links related to the relocation to vxsuite.

Of note:

- Our FIPS-compliant OpenSSL build process is now part of vxpollbook
- Rust version update (build would break using the old version)
- The workaround for libs/fixtures is similar to our approach in complete-system. Rather than symlink the entire vxsuite repo, I chose to only copy over what vxpollbook was erroring on during initialization