### PR TITLE
Add support for encrypted /var

### DIFF
--- a/playbooks/trusted_build/pollbook_build.yaml
+++ b/playbooks/trusted_build/pollbook_build.yaml
@@ -5,6 +5,7 @@
   become: yes
 
 - import_playbook: packages.yaml
+- import_playbook: initialize_encrypted_volumes.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml
 - import_playbook: rust_targets.yaml

--- a/playbooks/virtmanager/templates/pollbook-preseed.cfg.j2
+++ b/playbooks/virtmanager/templates/pollbook-preseed.cfg.j2
@@ -263,7 +263,7 @@ d-i partman-auto/expert_recipe string     \
     filesystem{ ext2 }                     \
     mountpoint{ /boot }                   \
     .                                     \
-    14000 800 14000 ext4                    \
+    8000 800 8000 ext4                    \
     \$lvmok{ }                            \
     method{ format }                      \
     format{ }                             \
@@ -282,7 +282,7 @@ d-i partman-auto/expert_recipe string     \
    use_filesystem{ } filesystem{ ext4 }     \
     mountpoint{ /tmp }                    \
     .                                     \
-    13000 3000 13000 ext4                   \
+    15000 3000 15000 ext4                   \
     \$lvmok{ }                            \
     method{ format }                      \
     format{ }                             \


### PR DESCRIPTION
This PR adds the playbook necessary to initialize an encrypted `/var` partition. It also updates the preseed used for pollbook builds since LVM sizes needed changes.