### PR TITLE
remove reference to old cups apparmor profile

### DIFF
--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -182,7 +182,6 @@ sudo cp $standard_config_files_dir/cups.service /usr/lib/systemd/system/
 
 # modified apparmor profiles to allow cups to access config files in /var
 sudo cp $standard_config_files_dir/apparmor.d/usr.sbin.cupsd /etc/apparmor.d/
-sudo cp $standard_config_files_dir/apparmor.d/usr.sbin.cups-browsed /etc/apparmor.d/
 
 # copy any modprobe configs we might use
 sudo cp $standard_config_files_dir/modprobe.d/10-i915.conf /etc/modprobe.d/


### PR DESCRIPTION
The cups-browsed apparmor profile has been removed. This removes the reference to it during setup.