### PR TITLE
Add missing package

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -63,6 +63,7 @@ all_packages:
   - make
   - mingetty
   - openbox
+  - pahole
   - parted
   - pcscd
   - pcsc-tools


### PR DESCRIPTION
In my most recent build attempt, we found that this package was necessary:

```
Package pahole is not installed
```

This dependency showed up after we moved to the 6.12 kernel, but we weren't sure if it was only a dependency as a result of networking related functionality in VxPollBook. Now we know and can add it to the `latest` inventory (which serves as the base for non-VxPollBook VxSuite inventories) - it was already in the `vxpollbook-latest` inventory.