### PR TITLE
Add ddcutil package

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -18,6 +18,7 @@ all_packages:
   - cups-bsd
   - cups-client
   - curl
+  - ddcutil
   - default-jdk
   - dosfstools
   - efitools

--- a/inventories/vxdev-stable/group_vars/all/packages.yaml
+++ b/inventories/vxdev-stable/group_vars/all/packages.yaml
@@ -18,6 +18,7 @@ all_packages:
   - cups-bsd
   - cups-client
   - curl
+  - ddcutil
   - default-jdk
   - dosfstools
   - efitools

--- a/inventories/vxpollbook-latest/group_vars/all/packages.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/packages.yaml
@@ -18,6 +18,7 @@ all_packages:
   - cups-bsd
   - cups-client
   - curl
+  - ddcutil
   - default-jdk
   - dosfstools
   - efitools


### PR DESCRIPTION
This PR adds the `ddcutil` package so we can manage brightness of screens that do not work via `brightnessctl`. 