### PR TITLE
Add ipsec and firewalld support in signed images

### DIFF
--- a/playbooks/trusted_build/pollbook_firewalld.yaml
+++ b/playbooks/trusted_build/pollbook_firewalld.yaml
@@ -23,11 +23,5 @@
     - name: Deny all other outgoing traffic
       ansible.builtin.command: "firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 9 -j DROP"
 
-    - name: Block incoming services enabled by default
-      ansible.builtin.command: "firewall-cmd --remove-service={{ item }} --permanent"
-      with_items:
-        - ssh
-        - dhcpv6-client
-
     - name: Reload to save and apply changes
       ansible.builtin.command: "firewall-cmd --reload"

--- a/playbooks/trusted_build/pollbook_firewalld.yaml
+++ b/playbooks/trusted_build/pollbook_firewalld.yaml
@@ -1,0 +1,33 @@
+---
+- name: Manage firewalld rules for pollbook systems
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  #TODO: This is identical to firewalld, just with mesh0 added
+  #      Possible candidate for future refactor/combine
+  tasks:
+
+    - name: Ensure firewalld starts on boot and is running
+      ansible.builtin.service:
+        name: firewalld
+        state: started
+        enabled: yes
+
+    - name: Allow localhost/loopback traffic
+      ansible.builtin.command: "firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 0 -o lo -j ACCEPT"
+
+    - name: Allow mesh0 traffic
+      ansible.builtin.command: "firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -o mesh0 -j ACCEPT"
+
+    - name: Deny all other outgoing traffic
+      ansible.builtin.command: "firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 9 -j DROP"
+
+    - name: Block incoming services enabled by default
+      ansible.builtin.command: "firewall-cmd --remove-service={{ item }} --permanent"
+      with_items:
+        - ssh
+        - dhcpv6-client
+
+    - name: Reload to save and apply changes
+      ansible.builtin.command: "firewall-cmd --reload"

--- a/playbooks/trusted_build/pollbook_firewalld.yaml
+++ b/playbooks/trusted_build/pollbook_firewalld.yaml
@@ -4,8 +4,6 @@
   connection: local
   become: true
 
-  #TODO: This is identical to firewalld, just with mesh0 added
-  #      Possible candidate for future refactor/combine
   tasks:
 
     - name: Ensure firewalld starts on boot and is running
@@ -14,14 +12,20 @@
         state: started
         enabled: yes
 
-    - name: Allow localhost/loopback traffic
-      ansible.builtin.command: "firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 0 -o lo -j ACCEPT"
+    - name: Set the default zone to "drop" so all traffic is dropped by default
+      ansible.builtin.command: "firewall-cmd --set-default-zone=drop"
 
-    - name: Allow mesh0 traffic
-      ansible.builtin.command: "firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -o mesh0 -j ACCEPT"
+    - name: Create a new zone for the mesh interface (mesh0)
+      ansible.builtin.command: "firewall-cmd --permanent --new-zone=mesh"
 
-    - name: Deny all other outgoing traffic
-      ansible.builtin.command: "firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 9 -j DROP"
+    - name: Accept all traffic in the mesh zone
+      ansible.builtin.command: "firewall-cmd --permanent --zone=mesh --set-target=ACCEPT"
+
+    - name: Add the mesh0 interface to the mesh zone
+      ansible.builtin.command: "firewall-cmd --permanent --zone=mesh --add-interface=mesh0"
+
+    - name: Make sure the loopback interface is part of the "trusted" zone
+      ansible.builtin.command: "firewall-cmd --permanent --zone=trusted --add-interface=lo"
 
     - name: Reload to save and apply changes
       ansible.builtin.command: "firewall-cmd --reload"

--- a/scripts/pollbook-files/update-ipsec.sh
+++ b/scripts/pollbook-files/update-ipsec.sh
@@ -10,7 +10,8 @@ echo "Updating IPsec config with new IP: $MESH_IP"
 
 # Update /etc/ipsec.conf:
 #   - Replaces the line starting with "left=" in the "meshvpn" connection
-sudo sed -i "s/^[[:space:]]*left=.*$/    left=$MESH_IP/" /etc/ipsec.conf
+sudo sed "s/^[[:space:]]*left=.*$/    left=$MESH_IP/" /etc/ipsec.conf > /var/tmp/ipsec.conf
+sudo cp /var/tmp/ipsec.conf /etc/ipsec.conf
 
 # Restart strongSwan so it picks up the new IP
 sudo ipsec restart

--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -90,4 +90,7 @@ set +e
     cp -rp "${vxsuite_dir}/libs/fixtures" "${BUILD_ROOT}/vxpollbook/libs/"
   )
 
+# This runs as the very last step since it locks the network down
+# to only loopback and mesh traffic
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/pollbook_build.yaml
 exit 0

--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -92,5 +92,5 @@ set +e
 
 # This runs as the very last step since it locks the network down
 # to only loopback and mesh traffic
-ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/pollbook_build.yaml
+ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/pollbook_firewalld.yaml
 exit 0

--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -322,10 +322,16 @@ sudo chown -h vx-vendor:vx-group /vx/config/openssl.cnf
 # This requires modifying files on the read-only root filesystem
 # so we create a symlink structure to enable writes to those files
 sudo mkdir -p /vx/config/etc
+
+# Pollbook: Host/Hostname links
 sudo mv /etc/hosts /vx/config/etc/hosts
 sudo ln -fs /vx/config/etc/hosts /etc/hosts
 sudo mv /etc/hostname /vx/config/etc/hostname
 sudo ln -fs /vx/config/etc/hostname /etc/hostname
+
+# Pollbook: IPSec links
+sudo mv /etc/ipsec.conf /vx/config/etc/ipsec.conf
+sudo ln -fs /vx/config/etc/ipsec.conf /etc/ipsec.conf
 
 # non-graphical login
 sudo systemctl set-default multi-user.target

--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -333,6 +333,8 @@ sudo ln -fs /vx/config/etc/hostname /etc/hostname
 sudo mv /etc/ipsec.conf /vx/config/etc/ipsec.conf
 sudo ln -fs /vx/config/etc/ipsec.conf /etc/ipsec.conf
 
+sudo cp ${complete_system_dir}/config/interfaces /etc/network/interfaces
+
 # non-graphical login
 sudo systemctl set-default multi-user.target
 


### PR DESCRIPTION
This PR uses our standard symlink approach to allow changes to files normally on the read-only root filesystem. It also adds a set of firewall rules to limit traffic to the loopback and mesh interfaces.