### PR TITLE
updates to support latest Parallels version

### DIFF
--- a/parallels-debian12.pkr.hcl
+++ b/parallels-debian12.pkr.hcl
@@ -3,7 +3,7 @@ packer {
 
   required_plugins {
     parallels = {
-      version = ">= 1.1.5"
+      version = ">= 1.2.8"
       source  = "github.com/hashicorp/parallels"
     }
     ansible = {

--- a/preseeds/base-preseed.cfg
+++ b/preseeds/base-preseed.cfg
@@ -33,6 +33,7 @@ d-i pkgsel/include string sudo vim git cups build-essential rsync cryptsetup efi
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
+d-i netcfg/choose_interface select auto
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false


### PR DESCRIPTION
The latest version of Parallels requires an updated plugin and a new preseed config option.