### PR TITLE
Bump vxsuite-complete-system reference to v4.0.2-rc4

### DIFF
--- a/inventories/v4.0.2/group_vars/all/main.yaml
+++ b/inventories/v4.0.2/group_vars/all/main.yaml
@@ -1,6 +1,6 @@
 repos:
   vxsuite-complete-system:
-    version: v4.0.2-rc3
+    version: v4.0.2-rc4
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-v4.0.2"
 vm_disk_size_gb: 27


### PR DESCRIPTION
I'm updating this reference on vxsuite-build-system main for bookkeeping. For the actual patched v4.0.2 rc4 VxAdmin build, I'm gonna check out https://github.com/votingworks/vxsuite-build-system/releases/tag/v4.0.2 and then edit the inventory to refer to vxsuite-complete-system v4.0.2-rc4, just to make sure that I'm using the exact version of vxsuite-build-system that we used when making the original v4.0.2 images. Trying to keep the new image as minimally patched as possible.