### PR TITLE
dont allow scripts to run with incorrect sudo state

### DIFF
--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run this script as root via: sudo $0"
+  exit 1
+fi
+
 debian_version=$(cat /etc/debian_version | cut -d'.' -f1)
 
 # Update apt sources

--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: This script should not be run via sudo."
+  exit 1
+fi
+
 set -euo pipefail
 
 debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)

--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: This script should not be run via sudo."
+  exit 1
+fi
+
 local_user=`logname`
 local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 vxsuite_build_system_dir="${local_user_home_dir}/code/vxsuite-build-system"

--- a/scripts/setup-vxdev.sh
+++ b/scripts/setup-vxdev.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: This script should not be run via sudo."
+  exit 1
+fi
+
 set -euo pipefail
 
 default_inventory="vxdev-stable"

--- a/scripts/tb-clone-images.sh
+++ b/scripts/tb-clone-images.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: This script should not be run via sudo."
+  exit 1
+fi
+
 set -euo pipefail
 
 ansible_inventory=$1

--- a/scripts/tb-initialize-build-machine.sh
+++ b/scripts/tb-initialize-build-machine.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: This script should not be run via sudo."
+  exit 1
+fi
+
 set -euo pipefail
 
 ansible_inventory=$1

--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: This script should not be run via sudo."
+  exit 1
+fi
+
 set -euo pipefail
 
 debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ $EUID -eq 0 ]]; then
+  echo "ERROR: This script should not be run via sudo."
+  exit 1
+fi
+
 set -euo pipefail
 
 debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)


### PR DESCRIPTION
This PR adds sudo checks to scripts to help prevent running in the wrong context. While most scripts will still appear to work without issue, running with or without sudo can subtly change the environment, permissions, etc... in ways that break other parts of a system's configuration. 