### PR TITLE
Copy simulate script when making pollbook qa image

### DIFF
--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -32,6 +32,9 @@ if [[ $qa_image_flag == 'y' || $qa_image_flag == 'Y' ]]; then
     VENDOR_PASSWORD='insecure'
     echo "OK, creating a QA image with sudo privileges for the vx-vendor user and terminal access via TTY2."
     echo "Using password insecure for the vx-vendor user."
+    sudo cp $local_user_home_dir/code/vxsuite/apps/pollbook/backend/scripts/simulate_check_ins.ts $build_dir/vxpollbook/apps/pollbook/backend/.
+    sudo cp $local_user_home_dir/code/vxsuite/apps/pollbook/backend/scripts/simulate-check-ins $build_dir/vxpollbook/apps/pollbook/backend/.
+
 else
     IS_QA_IMAGE=0
     echo "Ok, creating a production image. No sudo privileges for anyone!"


### PR DESCRIPTION
Adds the commands to copy over the simulate script when making a QA pollbook image for convenience. 