### PR TITLE
Restart strongswan when restarting network

### DIFF
--- a/scripts/pollbook-files/setup_basic_mesh.sh
+++ b/scripts/pollbook-files/setup_basic_mesh.sh
@@ -36,4 +36,5 @@ echo "Bringing up the network and joining pollbook_mesh"
 sudo ip link set mesh0 up
 sudo iw dev mesh0 mesh join pollbook_mesh
 
+sudo systemctl restart strongswan
 echo "Successfully joined the network."


### PR DESCRIPTION
Adds a command to restart strongswan to the end of the script that is triggered by the join-mesh-network service. This is what is run on boot to join the mesh network and rerun when the "reset network" button is clicked in the app. Tested via an image and basic functionality testing. 