### PR TITLE
Use pre-built openssl with fips support when available

### DIFF
--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -1,7 +1,6 @@
 repos:
   vxsuite-complete-system:
-    #version: main
-    version: adam/update-kiosk-browser-commit
+    version: main
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-latest"
 vm_disk_size_gb: 27

--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -1,6 +1,7 @@
 repos:
   vxsuite-complete-system:
-    version: main
+    #version: main
+    version: adam/update-kiosk-browser-commit
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-latest"
 vm_disk_size_gb: 27

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -23,7 +23,7 @@
 
     - name: Try to download a prebuilt package
       ansible.builtin.get_url:
-        url: "{{ prebuilt_pkg_uurl }}"
+        url: "{{ prebuilt_pkg_url }}"
         dest: "{{ downloads_directory }}/"
       register: openssl_download
       tags:

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -19,7 +19,7 @@
 
     - name: Prebuilt package download path
       set_fact:
-        prebuilt_pkg_url: "https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/openssl-fips_{{ openssl_version }}_amd64.deb"
+        prebuilt_pkg_url: "https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/openssl-fips/openssl-fips_{{ openssl_version }}_amd64.deb"
 
     - name: Try to download a prebuilt package
       ansible.builtin.get_url:

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -69,7 +69,7 @@
         - name: Create a temporary install to build a package for installation
           ansible.builtin.shell:
             chdir: "{{ downloads_directory }}/openssl-{{ openssl_version }}"
-            cmd: "make install DESTDIR=/tmp/openssl-build"
+            cmd: "rm -rf /tmp/openssl-build && make install DESTDIR=/tmp/openssl-build"
           tags:
             - offline
 

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -72,7 +72,7 @@
             chdir: "{{ downloads_directory }}"
             cmd: "fpm -s dir -t deb -n openssl-fips -v {{ openssl_version }} --description \"FIPS-Enabled OpenSSL {{ openssl_version }}\" -C /tmp/openssl-build"
 
-      when: openssl_download.rc != 0
+      when: openssl_download is not failed
 
     - name: Install via the newly created package
       ansible.builtin.shell:

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -17,39 +17,67 @@
       set_fact:
         downloads_directory: "{{ well_known_paths['tools']['system_path'] }}"
 
-    - name: Download OpenSSL {{ openssl_version }} source code
+    - name: Prebuilt package download path
+      set_fact:
+        prebuilt_pkg_url: "https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/openssl-fips_{{ openssl_version }}_amd64.deb"
+
+    - name: Try to download a prebuilt package
       ansible.builtin.get_url:
-        url: "https://www.openssl.org/source/openssl-{{ openssl_version }}.tar.gz"
+        url: "{{ prebuilt_pkg_uurl }}"
         dest: "{{ downloads_directory }}/"
+      register: openssl_download
       tags:
         - online
 
-    - name: Extract OpenSSL {{ openssl_version }} source code
-      ansible.builtin.unarchive:
-        src: "{{ downloads_directory }}/openssl-{{ openssl_version }}.tar.gz"
-        dest: "{{ downloads_directory }}"
-        remote_src: yes
-      tags:
-        - offline
+    - name: Build OpenSSL with FIPS enabled when prebuilt package is unavailable
+      block:
+        - name: Download OpenSSL {{ openssl_version }} source code
+          ansible.builtin.get_url:
+            url: "https://www.openssl.org/source/openssl-{{ openssl_version }}.tar.gz"
+            dest: "{{ downloads_directory }}/"
+          tags:
+            - online
 
-    - name: Configure OpenSSL {{ openssl_version }} with FIPS support
-      ansible.builtin.shell:
-        chdir: "{{ downloads_directory }}/openssl-{{ openssl_version }}"
-        cmd: "./Configure enable-fips"
-      tags:
-        - offline
+        - name: Extract OpenSSL {{ openssl_version }} source code
+          ansible.builtin.unarchive:
+            src: "{{ downloads_directory }}/openssl-{{ openssl_version }}.tar.gz"
+            dest: "{{ downloads_directory }}"
+            remote_src: yes
+          tags:
+            - offline
 
-    - name: Build the OpenSSL {{ openssl_version }} binaries
-      ansible.builtin.shell:
-        chdir: "{{ downloads_directory }}/openssl-{{ openssl_version }}"
-        cmd: "make"
-      tags:
-        - offline
+        - name: Configure OpenSSL {{ openssl_version }} with FIPS support
+          ansible.builtin.shell:
+            chdir: "{{ downloads_directory }}/openssl-{{ openssl_version }}"
+            cmd: "./Configure enable-fips"
+          tags:
+            - offline
 
-    - name: Install the OpenSSL {{ openssl_version }} binaries
+        - name: Build the OpenSSL {{ openssl_version }} binaries
+          ansible.builtin.shell:
+            chdir: "{{ downloads_directory }}/openssl-{{ openssl_version }}"
+            cmd: "make"
+          tags:
+            - offline
+
+        - name: Create a temporary install to build a package for installation
+          ansible.builtin.shell:
+            chdir: "{{ downloads_directory }}/openssl-{{ openssl_version }}"
+            cmd: "make install DESTDIR=/tmp/openssl-build"
+          tags:
+            - offline
+
+        - name: Create a Debian package via FPM
+          ansible.builtin.shell:
+            chdir: "{{ downloads_directory }}"
+            cmd: "fpm -s dir -t deb -n openssl-fips -v {{ openssl_version }} --description \"FIPS-Enabled OpenSSL {{ openssl_version }}\" -C /tmp/openssl-build"
+
+      when: openssl_download.rc != 0
+
+    - name: Install via the newly created package
       ansible.builtin.shell:
-        chdir: "{{ downloads_directory }}/openssl-{{ openssl_version }}"
-        cmd: "make install"
+        chdir: "{{ downloads_directory }}"
+        cmd: "dpkg -i openssl-fips_{{ openssl_version }}_amd64.deb"
       tags:
         - offline
 

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -77,6 +77,8 @@
           ansible.builtin.shell:
             chdir: "{{ downloads_directory }}"
             cmd: "fpm -s dir -t deb -n openssl-fips -v {{ openssl_version }} --description \"FIPS-Enabled OpenSSL {{ openssl_version }}\" -C /tmp/openssl-build"
+          tags:
+            - offline
 
       when: (openssl_download is defined and openssl_download is failed) or not openssl_package_file.stat.exists
 

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -26,6 +26,7 @@
         url: "{{ prebuilt_pkg_url }}"
         dest: "{{ downloads_directory }}/"
       register: openssl_download
+      ignore_errors: true
       tags:
         - online
 

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -72,7 +72,7 @@
             chdir: "{{ downloads_directory }}"
             cmd: "fpm -s dir -t deb -n openssl-fips -v {{ openssl_version }} --description \"FIPS-Enabled OpenSSL {{ openssl_version }}\" -C /tmp/openssl-build"
 
-      when: openssl_download is not failed
+      when: openssl_download is failed
 
     - name: Install via the newly created package
       ansible.builtin.shell:

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -29,6 +29,11 @@
       tags:
         - online
 
+    - name: See if the prebuilt package is present
+      ansible.builtin.stat:
+        path: "{{ downloads_directory }}/openssl-fips_{{ openssl_version }}_amd64.deb"
+      register: openssl_package_file
+
     - name: Build OpenSSL with FIPS enabled when prebuilt package is unavailable
       block:
         - name: Download OpenSSL {{ openssl_version }} source code
@@ -72,9 +77,9 @@
             chdir: "{{ downloads_directory }}"
             cmd: "fpm -s dir -t deb -n openssl-fips -v {{ openssl_version }} --description \"FIPS-Enabled OpenSSL {{ openssl_version }}\" -C /tmp/openssl-build"
 
-      when: openssl_download is failed
+      when: openssl_download is failed or not openssl_package_file.stat.exists
 
-    - name: Install via the newly created package
+    - name: Install via the package file
       ansible.builtin.shell:
         chdir: "{{ downloads_directory }}"
         cmd: "dpkg -i openssl-fips_{{ openssl_version }}_amd64.deb"

--- a/playbooks/trusted_build/openssl_fips.yaml
+++ b/playbooks/trusted_build/openssl_fips.yaml
@@ -77,7 +77,7 @@
             chdir: "{{ downloads_directory }}"
             cmd: "fpm -s dir -t deb -n openssl-fips -v {{ openssl_version }} --description \"FIPS-Enabled OpenSSL {{ openssl_version }}\" -C /tmp/openssl-build"
 
-      when: openssl_download is failed or not openssl_package_file.stat.exists
+      when: (openssl_download is defined and openssl_download is failed) or not openssl_package_file.stat.exists
 
     - name: Install via the package file
       ansible.builtin.shell:


### PR DESCRIPTION
We use a FIPS compliant version of openssl that requires compiling from source. Since this rarely updates, it's more efficient to build a Debian package once and install from that during builds rather than compiling from source each time. This PR checks for an existing package, and if found, it installs that; otherwise, it builds from source as usual and creates a package that could be uploaded for future use.