### PR TITLE
Manage kernel upgrades against normal Debian repos and VxWorks self-hosted repos

### DIFF
--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -42,7 +42,7 @@
 
     - name: Get the latest kernel version available in bookworm-backports or apt snapshot
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-image-amd64 | grep -E \"backports|{{ apt_snapshot_date | default('')\" | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
+        cmd: "apt-cache madison linux-image-amd64 | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
       register: latest_kernel_version
       tags:
         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -49,7 +49,7 @@
 
     - name: Upgrade the kernel packages and dependencies
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version.stdout }} 'linux-image-{{ latest_kernel_version.stdout }}*deb12-amd64' 'linux-headers-{{ latest_kernel_version.stdout }}*deb12-amd64'"
+        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version.stdout }} linux-image-amd64={{ latest_kernel_version.stdout }} 'linux-headers-{{ latest_kernel_version.stdout }}*deb12-amd64'"
       when: upgrade_kernel
       tags:
         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -33,23 +33,61 @@
       tags:
         - online
 
-    - name: Get the latest linux-base version available in bookworm-backports or apt snapshot
+    - name: Get the latest linux-base version available in bookworm-backports
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-base | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
-      register: latest_linux_base_version
+        cmd: "apt-cache madison linux-base | grep backports | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
+      register: tmp_latest_linux_base_version
+      when: apt_snapshot_date is not defined
       tags:
         - online
 
-    - name: Get the latest kernel version available in bookworm-backports or apt snapshot
+    - name: Set the linux_base_version variable
+      ansible.builtin.set_fact:
+        latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
+      when: apt_snapshot_date is not defined and tmp_latest_linux_base_version is not skipped
+
+    - name: Get the latest linux-base version available in VotingWorks apt repo
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-image-amd64 | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
-      register: latest_kernel_version
+        cmd: "apt-cache madison linux-base | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
+      register: tmp_latest_linux_base_version
+      when: apt_snapshot_date is defined
       tags:
         - online
+
+    - name: Set the linux_base_version variable
+      ansible.builtin.set_fact:
+        latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
+      when: apt_snapshot_date is defined and tmp_latest_linux_base_version is not skipped
+
+    - name: Get the latest kernel version available in bookworm-backports
+      ansible.builtin.shell:
+        cmd: "apt-cache madison linux-image-amd64 | grep backports | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
+      register: tmp_latest_kernel_version
+      when: apt_snapshot_date is not defined
+      tags:
+        - online
+
+    - name: Set the latest_kernel_version variable
+      ansible.builtin.set_fact:
+        latest_kernel_version: "{{ tmp_latest_kernel_version.stdout }}"
+      when: apt_snapshot_date is not defined and tmp_latest_kernel_version is not skipped
+
+    - name: Get the latest kernel version available in VotingWorks apt repo
+      ansible.builtin.shell:
+        cmd: "apt-cache madison linux-image-amd64 | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
+      register: tmp_latest_kernel_version
+      when: apt_snapshot_date is defined
+      tags:
+        - online
+
+    - name: Set the latest_kernel_version variable
+      ansible.builtin.set_fact:
+        latest_kernel_version: "{{ tmp_latest_kernel_version.stdout }}"
+      when: apt_snapshot_date is defined and tmp_latest_kernel_version is not skipped
 
     - name: Upgrade the kernel packages and dependencies
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version.stdout }} linux-image-amd64={{ latest_kernel_version.stdout }} 'linux-headers-*deb12-amd64'"
+        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} linux-image-amd64={{ latest_kernel_version }} 'linux-headers-*deb12-amd64'"
       when: upgrade_kernel
       tags:
         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -49,7 +49,7 @@
 
     - name: Upgrade the kernel packages and dependencies
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version.stdout }} linux-image-amd64={{ latest_kernel_version.stdout }} 'linux-headers-{{ latest_kernel_version.stdout }}*deb12-amd64'"
+        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version.stdout }} linux-image-amd64={{ latest_kernel_version.stdout }} 'linux-headers-*deb12-amd64'"
       when: upgrade_kernel
       tags:
         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -33,16 +33,16 @@
       tags:
         - online
 
-    - name: Get the latest linux-base version available in bookworm-backports
+    - name: Get the latest linux-base version available in bookworm-backports or apt snapshot
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-base | grep backports | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
+        cmd: "apt-cache madison linux-base | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
       register: latest_linux_base_version
       tags:
         - online
 
-    - name: Get the latest kernel version available in bookworm-backports
+    - name: Get the latest kernel version available in bookworm-backports or apt snapshot
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-image-amd64 | grep backports | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
+        cmd: "apt-cache madison linux-image-amd64 | grep -E \"backports|{{ apt_snapshot_date | default('')\" | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
       register: latest_kernel_version
       tags:
         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -35,14 +35,14 @@
 
     - name: Get the latest linux-base version available in bookworm-backports or apt snapshot
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-base | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
+        cmd: "apt-cache madison linux-base | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
       register: latest_linux_base_version
       tags:
         - online
 
     - name: Get the latest kernel version available in bookworm-backports or apt snapshot
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-image-amd64 | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'-' -f1 | head -1"
+        cmd: "apt-cache madison linux-image-amd64 | grep -E \"backports|{{ apt_snapshot_date | default('') }}\" | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
       register: latest_kernel_version
       tags:
         - online


### PR DESCRIPTION
Debian's focus on overall stability results in maintaining a very old, but stable, kernel. Our hardware requirements necessitate using more recent kernels. Since we frequently build our applications against the latest available packages AND against apt snapshot repos that we maintain internally, it has become necessary to manage the upgrade process for kernel related installs.

This PR changes the logic used to identify the required versions of several kernel-related packages, eliminates the need to specify an explicit version for linux headers, and addresses a dumb Ansible variable behavior.

re: Ansible

Ansible tasks that register the output to a variable always succeed, regardless of whether the task itself was successful and met all required conditions or not. The initial approach to managing kernel upgrades across the publicly available Debian backports repo versus our (VxWorks) self-hosted repos did not account for differences in file-naming conventions and dependency resolution and this variable behavior. Initial attempts to use registered Ansible variables were not successful since it writes to the registered variable in all cases. Since there's no good `if/else` construct available for this use case, we check for versions in the backports repo versus no backports repo, and set the version based on which task succeeds without being skipped.

This has been tested against our default `latest` inventory, along with our most recent `v4.0.3` inventory without issue.