### PR TITLE
Base user/group management via Ansible playbook

### DIFF
--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -1,6 +1,6 @@
 repos:
   vxsuite-complete-system:
-    version: adam/migrate-users
+    version: main
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-latest"
 vm_disk_size_gb: 27

--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -1,6 +1,6 @@
 repos:
   vxsuite-complete-system:
-    version: main
+    version: adam/migrate-users
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "debian-latest"
 vm_disk_size_gb: 27

--- a/inventories/latest/group_vars/all/users.yaml
+++ b/inventories/latest/group_vars/all/users.yaml
@@ -1,0 +1,44 @@
+---
+system_groups:
+  vx-group:
+    gid: 800
+  adm:
+  audio:
+  lpadmin:
+  scanner:
+  plugdev:
+  uinput:
+  dialout:
+  gpio:
+  fai100:
+
+system_users:
+  vx-services:
+    uid: 1750
+    homedir: /var/vx/services
+    groups: 
+      - adm
+      - audio
+      - dialout
+      - fai100
+      - gpio
+      - lpadmin
+      - plugdev
+      - scanner
+      - uinput
+      - vx-group
+  vx-ui:
+    uid: 1751
+    homedir: /var/vx/ui
+    groups: 
+      - adm
+      - audio
+      - video
+      - vx-group
+  vx-vendor:
+    uid: 1752
+    homedir: /var/vx/vendor
+    groups:
+      - adm
+      - vx-group
+

--- a/playbooks/trusted_build/prepare_for_build.yaml
+++ b/playbooks/trusted_build/prepare_for_build.yaml
@@ -5,6 +5,7 @@
   become: yes
 
 - import_playbook: kernel.yaml
+- import_playbook: users.yaml
 - import_playbook: packages.yaml
 - import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml

--- a/playbooks/trusted_build/users.yaml
+++ b/playbooks/trusted_build/users.yaml
@@ -11,7 +11,7 @@
         gid: "{{ item.value.gid | default(omit) }}"
         state: "{{ item.value.state | default('present') }}"
       with_dict:
-        - "{{ system_groups }}"
+        - "{{ system_groups | default({}) }}"
 
     - name: Create users
       ansible.builtin.user:
@@ -23,5 +23,5 @@
         home: "{{ item.value.homedir | default('/home/item.key') }}"
         state: "{{ item.value.state | default('present') }}"
       with_dict:
-        - "{{ system_users }}"
+        - "{{ system_users | default({}) }}"
 

--- a/playbooks/trusted_build/users.yaml
+++ b/playbooks/trusted_build/users.yaml
@@ -8,7 +8,7 @@
     - name: Create groups
       ansible.builtin.group:
         name: "{{ item.key }}"
-        gid: "{{ item.value.gid | default('') }}"
+        gid: "{{ item.value.gid | default(omit) }}"
         state: "{{ item.value.state | default('present') }}"
       with_dict:
         - "{{ system_groups }}"

--- a/playbooks/trusted_build/users.yaml
+++ b/playbooks/trusted_build/users.yaml
@@ -1,0 +1,27 @@
+---
+- name: Create Vx users and groups
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+    - name: Create groups
+      ansible.builtin.group:
+        name: "{{ item.key }}"
+        gid: "{{ item.value.gid | default('') }}"
+        state: "{{ item.value.state | default('present') }}"
+      with_dict:
+        - "{{ system_groups }}"
+
+    - name: Create users
+      ansible.builtin.user:
+        name: "{{ item.key }}"
+        comment: "{{ item.value.comment | default('No Comment') }}"
+        uid: "{{ item.value.uid }}"
+        groups: "{{ item.value.groups | join(',') }}"
+        shell: "{{ item.value.shell | default('/bin/bash') }}"
+        home: "{{ item.value.homedir | default('/home/item.key') }}"
+        state: "{{ item.value.state | default('present') }}"
+      with_dict:
+        - "{{ system_users }}"
+

--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -30,4 +30,7 @@ else
   exit 1
 fi
 
+# Ansible 2.19 is a trip, breaks long-standing sudo inheritance behaviors
+echo "Defaults !tty_tickets" | sudo tee /etc/sudoers.d/vx
+
 exit 0

--- a/scripts/tb-install-ansible.sh
+++ b/scripts/tb-install-ansible.sh
@@ -71,5 +71,8 @@ function pip_install ()
 apt_install $phase
 pip_install $phase
 
+# Ansible 2.19 is a trip, breaks long-standing sudo inheritance behaviors
+echo "Defaults !tty_tickets" | sudo tee /etc/sudoers.d/vx
+
 echo "Done"
 exit 0


### PR DESCRIPTION
This PR moves base user/group creation from vxsuite-complete-system via setup-machine.sh to an Ansible playbook. Only the `latest` inventory is modified to use this new approach since the expectation for previous releases, e.g. `v4.0.3` is that they would use a versioned release tag. 

This also includes a simple fix to the vx user sudo configuration to address a recent change to how ansible-core manages inherited sudo privileges. There is probably more work to do here in the long run, but this is a safe and straightforward fix for now when ansible-core 2.19+ is included in a build.