### PR TITLE
Use a more explicit approach to kernel upgrades

### DIFF
--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -87,7 +87,7 @@
 
     - name: Upgrade the kernel packages and dependencies
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} linux-image-amd64={{ latest_kernel_version }} 'linux-headers-*deb12-amd64'"
+        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} linux-image-amd64={{ latest_kernel_version }} linux-headers-amd64={{ latest_kernel_version }}"
       when: upgrade_kernel
       tags:
         - online

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -59,35 +59,23 @@
         latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
       when: apt_snapshot_date is defined and tmp_latest_linux_base_version is not skipped
 
-    - name: Get the latest kernel version available in bookworm-backports
+    - name: Get the latest kernel image available
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-image-amd64 | grep backports | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
-      register: tmp_latest_kernel_version
-      when: apt_snapshot_date is not defined
+        cmd: "apt-cache search --names-only linux-image-[0-9] | sort -V | tail -1 | awk '{print $1}'"
+      register: latest_kernel_image
       tags:
         - online
 
-    - name: Set the latest_kernel_version variable
-      ansible.builtin.set_fact:
-        latest_kernel_version: "{{ tmp_latest_kernel_version.stdout }}"
-      when: apt_snapshot_date is not defined and tmp_latest_kernel_version is not skipped
-
-    - name: Get the latest kernel version available in VotingWorks apt repo
+    - name: Get the latest kernel headers available
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-image-amd64 | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
-      register: tmp_latest_kernel_version
-      when: apt_snapshot_date is defined
+        cmd: "apt-cache search --names-only linux-headers-[0-9] | sort -V | tail -1 | awk '{print $1}'"
+      register: latest_kernel_headers
       tags:
         - online
-
-    - name: Set the latest_kernel_version variable
-      ansible.builtin.set_fact:
-        latest_kernel_version: "{{ tmp_latest_kernel_version.stdout }}"
-      when: apt_snapshot_date is defined and tmp_latest_kernel_version is not skipped
 
     - name: Upgrade the kernel packages and dependencies
       ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} linux-image-amd64={{ latest_kernel_version }} linux-headers-amd64={{ latest_kernel_version }}"
+        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} {{ latest_kernel_image.stdout }} {{ latest_kernel_headers.stdout }}"
       when: upgrade_kernel
       tags:
         - online


### PR DESCRIPTION
We have previously relied on debian meta-packages for kernel images and headers during the upgrade process, and while it generally worked, it was possible for package repos to have mismatched versions between the meta-package, e.g. linux-image-amd64, and the actual latest version. Once the meta-package version aligns with the latest, everything is fine, but in that interim window, the kernel upgrades will break because of the version mismatch.

This new approach more explicitly searches for and defines the latest package versions rather than relying on the meta-packages. It also simplifies the kernel playbook since it uses a single approach for public and self-hosted apt repos.

This has been tested by running the kernel playbook in two VMs: one built against `latest` and the other built against `v4.0.3`. After confirming a successful upgrade in both cases, it was then tested against the `tb-run-online-phase.sh` step in freshly created VMs (`latest` and `v4.0.3`) to ensure no other package issues came up after the kernel upgrade.