### PR TITLE
Migrate udev rule definitions 

### DIFF
--- a/inventories/latest/group_vars/all/udev-rules.yaml
+++ b/inventories/latest/group_vars/all/udev-rules.yaml
@@ -1,0 +1,18 @@
+---
+udev_rules:
+  49-sane-missing-scanner:
+    rules: ATTRS{idVendor}=="04c5", MODE="0664", GROUP="scanner", ENV{libsane_matched}="yes"
+  50-custom-scanner:
+    rules: ATTRS{idVendor}=="0dd4", MODE="0664", GROUP="scanner"
+  50-gpio:
+    rules: |
+      SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R g+rw /sys/class/gpio'"
+      SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/devices/platform/INT33FF:00/gpiochip0/gpio/* && chmod -R g+rw /sys/devices/platform/INT33FF:00/gpiochip0/gpio/*'"
+  50-pdi-scanner:
+    rule: SUBSYSTEM=="usb", ATTR{idVendor}=="0bd7", ATTR{idProduct}=="a002", MODE="0660", GROUP="scanner"
+  50-uinput:
+    rules: KERNEL=="uinput", MODE="0660", GROUP="uinput"
+  55-fai100:
+    rules: ATTRS{idVendor}=="28cd", ATTRS{idProduct}=="4002", MODE="0664", GROUP="fai100"
+  60-fujitsu-printer:
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0430", ATTR{idProduct}=="0626", MODE="0660", GROUP="plugdev"

--- a/inventories/latest/group_vars/all/udev-rules.yaml
+++ b/inventories/latest/group_vars/all/udev-rules.yaml
@@ -1,4 +1,6 @@
 ---
+# Note: for multi-line rules, be sure to use the pipe operator
+#       see 50-gpio for an example
 udev_rules:
   49-sane-missing-scanner:
     rules: ATTRS{idVendor}=="04c5", MODE="0664", GROUP="scanner", ENV{libsane_matched}="yes"

--- a/inventories/latest/group_vars/all/udev-rules.yaml
+++ b/inventories/latest/group_vars/all/udev-rules.yaml
@@ -9,7 +9,7 @@ udev_rules:
       SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R g+rw /sys/class/gpio'"
       SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/devices/platform/INT33FF:00/gpiochip0/gpio/* && chmod -R g+rw /sys/devices/platform/INT33FF:00/gpiochip0/gpio/*'"
   50-pdi-scanner:
-    rule: SUBSYSTEM=="usb", ATTR{idVendor}=="0bd7", ATTR{idProduct}=="a002", MODE="0660", GROUP="scanner"
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0bd7", ATTR{idProduct}=="a002", MODE="0660", GROUP="scanner"
   50-uinput:
     rules: KERNEL=="uinput", MODE="0660", GROUP="uinput"
   55-fai100:

--- a/playbooks/trusted_build/udev-rules.yaml
+++ b/playbooks/trusted_build/udev-rules.yaml
@@ -1,0 +1,14 @@
+---
+- name: Manage udev rules
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+    - name: Create udev rule files
+      ansible.builtin.copy:
+        dest: "/etc/udev/rules.d/{{ item.key }}.rules"
+        content: "{{ item.value.rules }}"
+      with_dict:
+        - "{{ udev_rules }}"
+

--- a/playbooks/trusted_build/udev-rules.yaml
+++ b/playbooks/trusted_build/udev-rules.yaml
@@ -10,5 +10,5 @@
         dest: "/etc/udev/rules.d/{{ item.key }}.rules"
         content: "{{ item.value.rules }}"
       with_dict:
-        - "{{ udev_rules }}"
+        - "{{ udev_rules | default({}) }}"
 


### PR DESCRIPTION
This PR moves udev rule definition/creation into build-system rather than complete-system's file-based copy approach. (Associated complete-system PR is here)

Very open to feedback on this, but a key difference is that all udev rules will be installed on a system, regardless of application type. I don't really see a downside, but if we want to limit udev rules based on application type, that could be part of whatever the final equivalent to `setup-machine.sh` looks like in build-system once the migration is complete.