### PR TITLE
Managed system / user directories 

### DIFF
--- a/inventories/latest/group_vars/all/users.yaml
+++ b/inventories/latest/group_vars/all/users.yaml
@@ -52,6 +52,9 @@ system_dirs:
   /var/vx/config:
     user: vx-vendor
     group: vx-group
+  /var/vx/config/app-flags:
+    user: vx-vendor
+    group: vx-group
   /var/vx/data:
     user: vx-services
     group: vx-services

--- a/inventories/latest/group_vars/all/users.yaml
+++ b/inventories/latest/group_vars/all/users.yaml
@@ -42,3 +42,44 @@ system_users:
       - adm
       - vx-group
 
+system_dirs:
+  /vx:
+    user: root
+    group: root
+  /var/vx:
+    user: root
+    group: root
+  /var/vx/config:
+    user: vx-vendor
+    group: vx-group
+  /var/vx/data:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-mark:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-scan:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-sems-converter:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/admin-service:
+    user: vx-services
+    group: vx-services
+  /var/vx/ui:
+    user: vx-ui
+    group: vx-ui
+  /var/vx/services:
+    user: vx-services
+    group: vx-services
+  /var/vx/vendor:
+    user: vx-vendor
+    group: vx-vendor
+  /media/vx:
+    user: vx-ui
+    group: vx-group
+  /media/vx/usb-drive:
+    user: vx-ui
+    group: vx-group
+

--- a/playbooks/trusted_build/users.yaml
+++ b/playbooks/trusted_build/users.yaml
@@ -25,3 +25,11 @@
       with_dict:
         - "{{ system_users | default({}) }}"
 
+    - name: Ensure directories exist with correct user/group ownership
+      ansible.builtin.file:
+        path: "{{ item.key }}"
+        state: directory
+        owner: "{{ item.value.user }}"
+        group: "{{ item.value.group }}"
+      with_dict:
+        - "{{ system_dirs | default({}) }}"


### PR DESCRIPTION
This PR replaces complete-system directory creation/management found in `setup-machine.sh` as part of the `users.yaml` playbook.

Associated complete-system PR: https://github.com/votingworks/vxsuite-complete-system/pull/478