### PR TITLE
include fips_install_service in offline build

### DIFF
--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -16,6 +16,7 @@
 - import_playbook: firewalld.yaml
 - import_playbook: logrotate.yaml
 - import_playbook: rsyslog.yaml
+- import_playbook: fips_install_service.yaml
 - import_playbook: rekey_var_service.yaml
 - import_playbook: lm-sensors.yaml
 - import_playbook: expand_var_service.yaml


### PR DESCRIPTION
Add the fips_install_service playbook to the offline build playbook.