### PR TITLE
Trusted Build: Gate building of new machines (VxMark and VxPrint) behind flag

### DIFF
--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -59,7 +59,11 @@ make offline-kiosk-browser
 echo "Run build.sh in complete-system. This will take several minutes."
 sleep 5
 cd $vxsuite_complete_system_dir
-./build.sh
+if [[ "${2:-}" == "--include-new-machines" ]]; then
+  ./build.sh admin central-scan mark-scan scan mark print
+else
+  ./build.sh admin central-scan mark-scan scan
+fi
 
 # Node20 upgrade has modified the permissions on some cached build dirs
 # Reset them so they can later be deleted during final image creation

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -54,7 +54,11 @@ fi
 echo "Run prepare_build.sh in complete-system. This will take several minutes."
 sleep 5
 cd $vxsuite_complete_system_dir
-./prepare_build.sh
+if [[ "${2:-}" == "--include-new-machines" ]]; then
+  ./prepare_build.sh admin central-scan mark-scan scan mark print
+else
+  ./prepare_build.sh admin central-scan mark-scan scan
+fi
 
 echo "Download necessary tools for TPM."
 sleep 5


### PR DESCRIPTION
## Overview

Pairs with https://github.com/votingworks/vxsuite-complete-system/pull/492/commits/59c1f91bbb5297752d85437e37358cb6acfeca5b

By default, the Trusted Build commands will no longer build the new apps (VxMark, VxPrint). Those will now require an extra flag to build:

```
./scripts/tb-run-online-phase.sh <inventory-name> --include-new-machines
./scripts/tb-run-offline-phase.sh <inventory-name> --include-new-machines
```

In my next source code drop for SLI, I'll be excluding vxsuite's apps/mark and apps/print directories (just as I already exclude apps/design and apps/pollbook). This PR is just maintaining parity between what we're sharing with SLI and what SLI is building.

Note that I haven't historically excluded apps/mark. Just an oversight on my part when we first started doing source code drops for SLI. I'll proactively note its exclusion in the next drop and we can bring it back once we're ready for a new cert campaign including VxMark and VxPrint.

## Testing

Going to do some manual testing before merging