### PR TITLE
add firmware to support mesh network hardware via usb adapter

### DIFF
--- a/inventories/vxpollbook-latest/group_vars/all/packages.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/packages.yaml
@@ -20,6 +20,7 @@ all_packages:
   - exfatprogs
   - fdisk
   - firewalld
+  - firmware-ath9k-htc
   - firmware-amd-graphics
   - firmware-iwlwifi
   - firmware-linux


### PR DESCRIPTION
Adds the necessary firmware to support the USB mesh network adapter from ThinkPenguin.

This closes https://github.com/votingworks/vxsuite/issues/7098