### PR TITLE
Fix a typo in usbguard config

### DIFF
--- a/playbooks/trusted_build/usbguard.yaml
+++ b/playbooks/trusted_build/usbguard.yaml
@@ -53,7 +53,7 @@
     - name: Update the usbguard daemon config to implicitly allow unidentified devices
       ansible.builtin.lineinfile:
         path: /etc/usbguard/usbguard-daemon.conf
-        regexp: '^ImplictPolicyTarget='
+        regexp: '^ImplicitPolicyTarget='
         line: 'ImplicitPolicyTarget=allow'
         state: present
 


### PR DESCRIPTION
This PR fixes a typo in the usbguard daemon config file. 