### PR TITLE
VxPollBook: Update kiosk-browser installation command

### DIFF
--- a/scripts/prepare-vxpollbook-build.sh
+++ b/scripts/prepare-vxpollbook-build.sh
@@ -60,7 +60,7 @@ sudo -v
 cd $kiosk_browser_dir
 make install
 make build
-sudo dpkg -i dist/kiosk-browser_1.0.0_*.deb
+sudo dpkg -i dist/kiosk-browser_*.deb
 
 echo "Build VxPollbook"
 sleep 5


### PR DESCRIPTION
To account for the fact that the version number is no longer always 1.0.0

I ran a test build yesterday and it failed here. This should unblock!