### PR TITLE
build(rust): update to v1.93.0

### DIFF
--- a/inventories/latest/group_vars/all/main.yaml
+++ b/inventories/latest/group_vars/all/main.yaml
@@ -10,7 +10,7 @@ iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
-rust_version: "1.86.0"
+rust_version: "1.93.0"
 qa_image: true
 cloned_images:
   - online

--- a/inventories/parallels-latest/group_vars/all/main.yaml
+++ b/inventories/parallels-latest/group_vars/all/main.yaml
@@ -11,4 +11,4 @@ vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/pr
 vm_preseed_file: "production-preseed.cfg"
 secure_boot: true
 vm_clone_name: "deb12"
-rust_version: "1.86.0"
+rust_version: "1.93.0"

--- a/inventories/vxdev-stable/group_vars/all/main.yaml
+++ b/inventories/vxdev-stable/group_vars/all/main.yaml
@@ -10,6 +10,6 @@ iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "vxdev-preseed.cfg"
 secure_boot: true
-rust_version: "1.86.0"
+rust_version: "1.93.0"
 cloned_images:
   - vxdev

--- a/inventories/vxpollbook-latest/group_vars/all/main.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/main.yaml
@@ -14,7 +14,7 @@ iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso
 vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
 vm_preseed_file: "pollbook-preseed.cfg"
 secure_boot: true
-rust_version: "1.86.0"
+rust_version: "1.93.0"
 qa_image: true
 cloned_images:
   - pollbook

--- a/playbooks/install-rust.yaml
+++ b/playbooks/install-rust.yaml
@@ -5,7 +5,7 @@
   become: true
 
   vars:
-    rust_version: "1.86.0"
+    rust_version: "1.93.0"
     user_to_configure: "{{ ansible_env.SUDO_USER | default('root') }}"
     rustup_install_url: "https://sh.rustup.rs"
     rustup_install_cmd: "/tmp/rustup.sh"


### PR DESCRIPTION
Updates to the latest release of Rust. I've verified that vxsuite still builds properly against v1.93.0.