### PR TITLE
Prevent warnings from `script/package-cleanup.sh`

### DIFF
--- a/scripts/package-cleanup.sh
+++ b/scripts/package-cleanup.sh
@@ -8,8 +8,8 @@ if [[ "$debian_version" == "11" ]]; then
   DEBIAN_FRONTEND=noninteractive sudo python3.9 -m pip uninstall -y --break-system-packages ansible passlib
 fi
 
-DEBIAN_FRONTEND=noninteractive sudo apt autoremove -y
-DEBIAN_FRONTEND=noninteractive sudo apt clean
+DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y
+DEBIAN_FRONTEND=noninteractive sudo apt-get clean
 DEBIAN_FRONTEND=noninteractive sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 exit 0


### PR DESCRIPTION
There are two warnings that always makes me think something is wrong when I do a `packer build`:

```
==> debian12.docker.debian12: Provisioning with shell script: scripts/package-cleanup.sh
==> debian12.docker.debian12: sudo: python3.9: command not found
==> debian12.docker.debian12:
==> debian12.docker.debian12: WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

- `python3.9: command not found`: this is the one that trips me up because it looks like a true error. I always lose some time when I come back to vxsuite-build-system because I forget that this is just noise.
- `apt does not have a stable CLI interface`: I know this one is just a warning (it says it loud and clear), but the red text in the packer output still makes me think something is broken for a moment. I'd rather not have that tiny moment of panic every time I run `packer build`.

This fixes these by only trying to clean up the global python packages in a Debian 11 build (which is the only place they're installed globally and the only place python3.9 is installed), and by using `apt-get` instead of `apt`.