### PR TITLE
chore: update Debian 12 docker build versions to 4.3.0

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.2.0"
+  default = "4.3.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.2.0"
+  default = "4.3.0"
 }
 
 source "docker" "debian12" {


### PR DESCRIPTION
This version primarily bumps Rust from 1.86 to 1.93, but includes any changes since 8eb766a7.

I'll plan to build and push the new images once this is approved & merged.