### PR TITLE
build: remove `libzbar-dev`

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -55,7 +55,6 @@ all_packages:
   - libx11-dev
   - libxss1
   - libxtst6
-  - libzbar-dev
   - lm-sensors
   - make
   - mingetty

--- a/inventories/parallels-latest/group_vars/all/packages.yaml
+++ b/inventories/parallels-latest/group_vars/all/packages.yaml
@@ -42,7 +42,6 @@ all_packages:
   - libx11-dev
   - libxss1
   - libxtst6
-  - libzbar-dev
   - make
   - mingetty
   - openbox

--- a/inventories/vxdev-stable/group_vars/all/packages.yaml
+++ b/inventories/vxdev-stable/group_vars/all/packages.yaml
@@ -57,7 +57,6 @@ all_packages:
   - libx11-dev
   - libxss1
   - libxtst6
-  - libzbar-dev
   - make
   - mingetty
   - openbox

--- a/inventories/vxpollbook-latest/group_vars/all/packages.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/packages.yaml
@@ -58,7 +58,6 @@ all_packages:
   - libx11-dev
   - libxss1
   - libxtst6
-  - libzbar-dev
   - make
   - mingetty
   - openbox

--- a/playbooks/install-vxsuite-packages.yaml
+++ b/playbooks/install-vxsuite-packages.yaml
@@ -43,7 +43,6 @@
       - libx11-dev
       - libxss1
       - libxtst6
-      - libzbar-dev
       - make
       - mingetty
       - openbox


### PR DESCRIPTION
vxsuite now uses zedbar rather than relying on the system zbar library to be installed: https://github.com/votingworks/vxsuite/pull/8003.