### PR TITLE
feat: nodejs 20.16 -> 20.19

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.3.0"
+  default = "4.4.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.3.0"
+  default = "4.4.0"
 }
 
 source "docker" "debian12" {

--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.16.0"
+node_version: "20.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.16.0"
+node_version: "20.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.16.0"
+node_version: "20.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/inventories/vxpollbook-latest/group_vars/all/node.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.16.0"
+node_version: "20.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -5,7 +5,7 @@
   become: true
 
   vars:
-    node_version: "20.16.0"
+    node_version: "20.19.0"
     npm_packages:
       - yarn@1.22.22
       - pnpm@8.15.5


### PR DESCRIPTION
Updates the docker tag to v4.4.0 for the debian12 images. This change is to support vite 8, which requires >= 20.19 on the 20.x release branch.

vite 8 needs this feature which is not present in 20.16: [require(esm) is now enabled by default](https://github.com/nodejs/node/releases/tag/v20.19.0)