### PR TITLE
Adjust partition sizes to get builds working again

### DIFF
--- a/playbooks/virtmanager/templates/production-preseed.cfg.j2
+++ b/playbooks/virtmanager/templates/production-preseed.cfg.j2
@@ -263,7 +263,7 @@ d-i partman-auto/expert_recipe string     \
     filesystem{ ext2 }                     \
     mountpoint{ /boot }                   \
     .                                     \
-    9000 800 9000 ext4                    \
+    8000 800 8000 ext4                    \
     \$lvmok{ }                            \
     method{ format }                      \
     format{ }                             \
@@ -282,7 +282,7 @@ d-i partman-auto/expert_recipe string     \
    use_filesystem{ } filesystem{ ext4 }     \
     mountpoint{ /tmp }                    \
     .                                     \
-    15000 3000 15000 ext4                   \
+    11500 3000 11500 ext4                   \
     \$lvmok{ }                            \
     method{ format }                      \
     format{ }                             \


### PR DESCRIPTION
We bumped partition sizes in https://github.com/votingworks/vxsuite-build-system/pull/220 to get builds working again. But this didn't quite work as increasing the size of the root and home partitions implicitly required decreasing the size of the var partition, and all three are used at different points during the build process.

The total base image size is 27GB. While we could bump the total, VSAP can only handle a 27GB image. (On other machines, we dynamically expand the var partition to take up all remaining available space.) We could have different base image files for VSAP (i.e. VxMarkScan) vs. all other machines, but it's nice to have only one base image.

Through trial and error, I found that allocating just 0.5GB extra to the home partition (and taking that away from the var partition) seems to work.

There are better long-term solutions, but I just need to unblock v4.0.5 builds for now. During the build process, we often download content to one partition and then copy it to another. Perhaps we could directly download some contents to the destination partition to decrease space needs of other partitions. We could also optimize the vxsuite build itself and prune unneeded contents.

