### PR TITLE
make `/media/vx` a `tmpfs` for dynamic USB drive mounts

### DIFF
--- a/inventories/latest/group_vars/all/users.yaml
+++ b/inventories/latest/group_vars/all/users.yaml
@@ -88,7 +88,4 @@ system_dirs:
   /media/vx:
     user: vx-ui
     group: vx-group
-  /media/vx/usb-drive:
-    user: vx-ui
-    group: vx-group
 

--- a/inventories/v4.0.4/group_vars/all/users.yaml
+++ b/inventories/v4.0.4/group_vars/all/users.yaml
@@ -88,7 +88,4 @@ system_dirs:
   /media/vx:
     user: vx-ui
     group: vx-group
-  /media/vx/usb-drive:
-    user: vx-ui
-    group: vx-group
 

--- a/playbooks/trusted_build/files/media-vx.mount
+++ b/playbooks/trusted_build/files/media-vx.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tmpfs for USB drive mount points
+
+[Mount]
+What=tmpfs
+Where=/media/vx
+Type=tmpfs
+Options=mode=0755,nosuid,nodev,noexec
+
+[Install]
+WantedBy=local-fs.target

--- a/playbooks/trusted_build/post_build_config.yaml
+++ b/playbooks/trusted_build/post_build_config.yaml
@@ -91,6 +91,17 @@
       ansible.builtin.shell:
         cmd: "rm -rf /var/tmp/rust*"
 
+    - name: Install media-vx tmpfs mount unit
+      ansible.builtin.copy:
+        src: "files/media-vx.mount"
+        dest: "/etc/systemd/system/media-vx.mount"
+        mode: 0644
+
+    - name: Enable media-vx tmpfs mount
+      ansible.builtin.systemd_service:
+        name: media-vx.mount
+        enabled: true
+
     - name: Ensure a systemctl daemon-reload
       ansible.builtin.systemd_service:
         daemon_reload: true

--- a/scripts/pollbook-files/media-vx.mount
+++ b/scripts/pollbook-files/media-vx.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tmpfs for USB drive mount points
+
+[Mount]
+What=tmpfs
+Where=/media/vx
+Type=tmpfs
+Options=mode=0755,nosuid,nodev,noexec
+
+[Install]
+WantedBy=local-fs.target

--- a/scripts/setup-pollbook-machine.sh
+++ b/scripts/setup-pollbook-machine.sh
@@ -142,9 +142,12 @@ sudo usermod -aG plugdev vx-services
 # Set up log config
 (cd $complete_system_dir && sudo bash setup-scripts/setup-logging.sh)
 
-# set up mount point ahead of time because read-only later
-sudo mkdir -p /media/vx/usb-drive
-sudo chown -R vx-ui:vx-group /media/vx
+# create the /media/vx anchor directory; a tmpfs is mounted over it at boot
+# to allow dynamic USB drive mount points on the read-only root filesystem
+sudo mkdir -p /media/vx
+sudo cp $pollbook_config_files_dir/media-vx.mount /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable media-vx.mount
 
 # let vx-services manage printers
 sudo usermod -aG lpadmin vx-services


### PR DESCRIPTION
See discussion in [Slack](https://votingworks.slack.com/archives/CFSJEQ26N/p1774396877017629?thread_ts=1774392047.571089&cid=CFSJEQ26N).

With a single USB drive, we previously pre-created `/media/vx/usb-drive` as the mount point for that single drive. Now, [we mount at paths based on the mounted partition e.g. `/media/vx/usb-drive-sdb1`](https://github.com/votingworks/vxsuite/pull/8144). Since the root filesystem is read-only, we need to make `/media/vx` writable somehow. Since the mounts are not persisted across reboots, a `tmpfs` filesystem makes sense.

I could not get a full QA build working locally to test this, but I did create a Debian 12 VM without Gnome/KDE/etc. and added the `systemd` unit from this PR and validated that the `tmpfs` at `/media/vx` is mounted on boot and that creating and removing directories works as expected:

```
root@localhost:~# mount | grep /media
tmpfs on /media/vx type tmpfs (rw,nosuid,nodev,noexec,relatime,mode=755,inode64)
root@localhost:~# mkdir /media/vx/test1
root@localhost:~# ls -l /media/vx
total 0
drwxr-xr-x 2 root root 40 Mar 25 13:20 test1
root@localhost:~# rmdir /media/vx/test1
root@localhost:~# ls -l /media/vx
total 0
```