### PR TITLE
Keep v4.0.5 inventory on Node 20.16.0

### DIFF
--- a/inventories/v4.0.5/group_vars/all/node.yaml
+++ b/inventories/v4.0.5/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.19.0"
+node_version: "20.16.0"
 npm_packages:
   yarn:
     version: "1.22.22"


### PR DESCRIPTION
For consistency with the targeted vxsuite-complete-system/vxsuite code

While vxsuite main is running 20.19.0, the release branch that we're targeting is still on 20.16.0. Trying to cherry-pick the 20.19.0 upgrade onto that release branch results in too many merge conflicts to safely resolve.