### PR TITLE
some initial vxdev updates

### DIFF
--- a/inventories/vxdev-stable/group_vars/all/udev-rules.yaml
+++ b/inventories/vxdev-stable/group_vars/all/udev-rules.yaml
@@ -1,0 +1,20 @@
+---
+# Note: for multi-line rules, be sure to use the pipe operator
+#       see 50-gpio for an example
+udev_rules:
+  49-sane-missing-scanner:
+    rules: ATTRS{idVendor}=="04c5", MODE="0664", GROUP="scanner", ENV{libsane_matched}="yes"
+  50-custom-scanner:
+    rules: ATTRS{idVendor}=="0dd4", MODE="0664", GROUP="scanner"
+  50-gpio:
+    rules: |
+      SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R g+rw /sys/class/gpio'"
+      SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/devices/platform/INT33FF:00/gpiochip0/gpio/* && chmod -R g+rw /sys/devices/platform/INT33FF:00/gpiochip0/gpio/*'"
+  50-pdi-scanner:
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0bd7", ATTR{idProduct}=="a002", MODE="0660", GROUP="scanner"
+  50-uinput:
+    rules: KERNEL=="uinput", MODE="0660", GROUP="uinput"
+  55-fai100:
+    rules: ATTRS{idVendor}=="28cd", ATTRS{idProduct}=="4002", MODE="0664", GROUP="fai100"
+  60-fujitsu-printer:
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0430", ATTR{idProduct}=="0626", MODE="0660", GROUP="plugdev"

--- a/playbooks/trusted_build/setup_vxdev.yaml
+++ b/playbooks/trusted_build/setup_vxdev.yaml
@@ -6,11 +6,11 @@
 
 - import_playbook: kernel.yaml
 - import_playbook: packages.yaml
+- import_playbook: udev-rules.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml
 - import_playbook: rubygems.yaml
 - import_playbook: logrotate.yaml
-- import_playbook: ../manage-udev-rules.yaml
 - import_playbook: ../manage-cups.yaml
 - import_playbook: repos.yaml
 - import_playbook: tpm.yaml

--- a/scripts/setup-vxdev.sh
+++ b/scripts/setup-vxdev.sh
@@ -42,6 +42,7 @@ fi
 
 echo "Run setup_vxdev playbook. This will take several minutes."
 sleep 5
+sudo -v
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/setup_vxdev.yaml
 
 if [[ ! -d $vxsuite_complete_system_dir ]]; then


### PR DESCRIPTION
This PR brings the vxdev build environment more in-line with latest build processes. 

- It uses the udev-rules playbook and pattern rather than manual copy operations in complete-system
- It addresses a change in how sudo sessions are managed by Ansible