### PR TITLE
Only install and configure networking functionality when enabled via inventory config

### DIFF
--- a/inventories/latest/group_vars/all/networking.yaml
+++ b/inventories/latest/group_vars/all/networking.yaml
@@ -1,5 +1,5 @@
 ---
-enable_networking: false
+enable_networking: true
 
 networking_packages:
   - avahi-daemon

--- a/inventories/latest/group_vars/all/networking.yaml
+++ b/inventories/latest/group_vars/all/networking.yaml
@@ -1,5 +1,5 @@
 ---
-enable_networking: true
+enable_networking: false
 
 networking_packages:
   - avahi-daemon

--- a/inventories/latest/group_vars/all/networking.yaml
+++ b/inventories/latest/group_vars/all/networking.yaml
@@ -1,0 +1,13 @@
+---
+enable_networking: true
+
+networking_packages:
+  - avahi-daemon
+  - avahi-utils
+  - strongswan-swanctl
+  - libstrongswan-extra-plugins
+  - libstrongswan-standard-plugins
+  - charon-systemd
+  - strongswan-pki
+  - avahi-autoipd
+  - iw

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -93,17 +93,6 @@ all_packages:
   - xxd
   - zip
 
-networking_packages:
-  - avahi-daemon
-  - avahi-utils
-  - strongswan-swanctl
-  - libstrongswan-extra-plugins
-  - libstrongswan-standard-plugins
-  - charon-systemd
-  - strongswan-pki
-  - avahi-autoipd
-  - iw
-
 tpm_packages:
   - autoconf
   - autoconf-archive

--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -92,6 +92,8 @@ all_packages:
   - xserver-xorg-video-all
   - xxd
   - zip
+
+networking_packages:
   - avahi-daemon
   - avahi-utils
   - strongswan-swanctl

--- a/inventories/v4.0.6/group_vars/all/brother.yaml
+++ b/inventories/v4.0.6/group_vars/all/brother.yaml
@@ -1,0 +1,13 @@
+---
+brother_32bit_packages:
+  - libc6:i386
+  - libncurses5:i386
+  - libstdc++6:i386
+
+brother_drivers:
+  PJ-822:
+    url: "https://download.brother.com/welcome/dlfp100949/pj822pdrv-1.2.0-1.i386.deb"
+    checksum: "c1fae128905bc0dbe91080fd08adc62cb2e4f7b959291d91e8294cd3f91dadf3"
+  PJ-823:
+    url: "https://download.brother.com/welcome/dlfp100952/pj823pdrv-1.2.0-1.i386.deb"
+    checksum: "933b99e2963f5642f84474a288b1e867384bda0b0440ec36a8d22e05e8478546"

--- a/inventories/v4.0.6/group_vars/all/main.yaml
+++ b/inventories/v4.0.6/group_vars/all/main.yaml
@@ -1,0 +1,15 @@
+repos:
+  vxsuite-complete-system:
+    version: v4.0.6-release-branch
+virt_image_path: "/var/lib/libvirt/images"
+vm_name: "debian-v4.0.6"
+vm_disk_size_gb: 27
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
+vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
+vm_preseed_file: "production-preseed.cfg"
+secure_boot: true
+rust_version: "1.93.0"
+cloned_images:
+  - online

--- a/inventories/v4.0.6/group_vars/all/networking.yaml
+++ b/inventories/v4.0.6/group_vars/all/networking.yaml
@@ -1,0 +1,13 @@
+---
+enable_networking: false
+
+networking_packages:
+  - avahi-daemon
+  - avahi-utils
+  - strongswan-swanctl
+  - libstrongswan-extra-plugins
+  - libstrongswan-standard-plugins
+  - charon-systemd
+  - strongswan-pki
+  - avahi-autoipd
+  - iw

--- a/inventories/v4.0.6/group_vars/all/node.yaml
+++ b/inventories/v4.0.6/group_vars/all/node.yaml
@@ -1,0 +1,8 @@
+node_version: "20.16.0"
+npm_packages:
+  yarn:
+    version: "1.22.22"
+    checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  pnpm:
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/v4.0.6/group_vars/all/packages.yaml
+++ b/inventories/v4.0.6/group_vars/all/packages.yaml
@@ -1,0 +1,126 @@
+---
+batch_package_install: true
+upgrade_kernel: true
+#apt_snapshot_date: "20260325"
+#release_name: "bookworm"
+
+all_packages:
+  - alsa-utils
+  - brightnessctl
+  - build-essential
+  - chromium
+  - cloud-guest-utils
+  - cryptsetup
+  - cups
+  - cups-bsd
+  - cups-client
+  - curl
+  - ddcutil
+  - default-jdk
+  - dosfstools
+  - efitools
+  - exfatprogs
+  - fdisk
+  - firewalld
+  - firmware-amd-graphics
+  - firmware-linux
+  - firmware-linux-free
+  - firmware-misc-nonfree
+  - firmware-sof-signed
+  - fonts-wqy-zenhei
+  - git
+  - gvfs
+  - gzip
+  - hplip
+  - ipp-usb
+  - iptables
+  - jq
+  - kde-cli-tools
+  - libatspi2.0-0
+  - libcairo2-dev
+  - libgif-dev
+  - libglib2.0-bin
+  - libgtk-3-0
+  - libjpeg-dev
+  - libnotify4
+  - libpango1.0-dev
+  - libpcsclite1
+  - libpcsclite-dev
+  - libpixman-1-dev
+  - libpng-dev
+  - libsane
+  - libsane1
+  - libsane-common
+  - libsane-hpaio
+  - libudev-dev
+  - libusb-1.0-0-dev
+  - libx11-dev
+  - libxss1
+  - libxtst6
+  - lm-sensors
+  - make
+  - mingetty
+  - openbox
+  - pahole
+  - parted
+  - pcscd
+  - pcsc-tools
+  - pulseaudio
+  - pulseaudio-utils
+  - rsync
+  - rsyslog
+  - ruby
+  - ruby-dev
+  - sane-airscan
+  - sane-utils
+  - sbsigntool
+  - swig
+  - systemd-boot-efi
+  - tar
+  - trash-cli
+  - unclutter
+  - unzip
+  - usbguard
+  - wget
+  - x11-common
+  - xdg-utils
+  - xinit
+  - xinput
+  - xorg
+  - xserver-xorg-core
+  - xserver-xorg-input-all
+  - xserver-xorg-input-libinput
+  - xserver-xorg-input-wacom
+  - xserver-xorg-video-all
+  - xxd
+  - zip
+
+tpm_packages:
+  - autoconf
+  - autoconf-archive
+  - automake
+  - autotools-dev
+  - libcurl4-openssl-dev
+  - libjson-c-dev
+  - libltdl-dev
+  - libqrencode4
+  - libqrencode-dev
+  - libssl-dev
+  - libtool
+  - libtss2-esys-3.0.2-0
+  - libtss2-fapi1
+  - libtss2-mu0
+  - libtss2-rc0
+  - libtss2-sys1
+  - libtss2-tcti-cmd0
+  - libtss2-tcti-device0
+  - libtss2-tctildr0
+  - libtss2-tcti-mssim0
+  - libtss2-tcti-swtpm0
+  - m4
+  - qrencode
+  - tpm2-openssl
+  - tpm2-tools
+
+dev_packages:
+  - ffmpeg

--- a/inventories/v4.0.6/group_vars/all/rubygems.yaml
+++ b/inventories/v4.0.6/group_vars/all/rubygems.yaml
@@ -1,0 +1,4 @@
+gems:
+  fpm:
+    version: "1.15.1"
+    checksum: "1ffbf342a89ca97fb5c02e66946c97e2bd5413810f7f440ddf32f00a16052dbf"

--- a/inventories/v4.0.6/group_vars/all/udev-rules.yaml
+++ b/inventories/v4.0.6/group_vars/all/udev-rules.yaml
@@ -1,0 +1,20 @@
+---
+# Note: for multi-line rules, be sure to use the pipe operator
+#       see 50-gpio for an example
+udev_rules:
+  49-sane-missing-scanner:
+    rules: ATTRS{idVendor}=="04c5", MODE="0664", GROUP="scanner", ENV{libsane_matched}="yes"
+  50-custom-scanner:
+    rules: ATTRS{idVendor}=="0dd4", MODE="0664", GROUP="scanner"
+  50-gpio:
+    rules: |
+      SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R g+rw /sys/class/gpio'"
+      SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/devices/platform/INT33FF:00/gpiochip0/gpio/* && chmod -R g+rw /sys/devices/platform/INT33FF:00/gpiochip0/gpio/*'"
+  50-pdi-scanner:
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0bd7", ATTR{idProduct}=="a002", MODE="0660", GROUP="scanner"
+  50-uinput:
+    rules: KERNEL=="uinput", MODE="0660", GROUP="uinput"
+  55-fai100:
+    rules: ATTRS{idVendor}=="28cd", ATTRS{idProduct}=="4002", MODE="0664", GROUP="fai100"
+  60-fujitsu-printer:
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0430", ATTR{idProduct}=="0626", MODE="0660", GROUP="plugdev"

--- a/inventories/v4.0.6/group_vars/all/users.yaml
+++ b/inventories/v4.0.6/group_vars/all/users.yaml
@@ -1,0 +1,94 @@
+---
+system_groups:
+  vx-group:
+    gid: 800
+  adm:
+  audio:
+  lpadmin:
+  scanner:
+  plugdev:
+  uinput:
+  dialout:
+  gpio:
+  fai100:
+
+system_users:
+  vx-services:
+    uid: 1750
+    homedir: /var/vx/services
+    groups: 
+      - adm
+      - audio
+      - dialout
+      - fai100
+      - gpio
+      - lpadmin
+      - plugdev
+      - scanner
+      - uinput
+      - vx-group
+    symlink: /vx/services
+  vx-ui:
+    uid: 1751
+    homedir: /var/vx/ui
+    groups: 
+      - adm
+      - audio
+      - video
+      - vx-group
+    symlink: /vx/ui
+  vx-vendor:
+    uid: 1752
+    homedir: /var/vx/vendor
+    groups:
+      - adm
+      - vx-group
+    symlink: /vx/vendor
+
+system_dirs:
+  /vx:
+    user: root
+    group: root
+  /var/vx:
+    user: root
+    group: root
+  /var/vx/config:
+    user: vx-vendor
+    group: vx-group
+  /var/vx/config/app-flags:
+    user: vx-vendor
+    group: vx-group
+  /var/vx/data:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-mark:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-mark-scan:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-scan:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-sems-converter:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/admin-service:
+    user: vx-services
+    group: vx-services
+  /var/vx/ui:
+    user: vx-ui
+    group: vx-ui
+  /var/vx/services:
+    user: vx-services
+    group: vx-services
+  /var/vx/vendor:
+    user: vx-vendor
+    group: vx-vendor
+  /media/vx:
+    user: vx-ui
+    group: vx-group
+  /media/vx/usb-drive:
+    user: vx-ui
+    group: vx-group
+

--- a/inventories/v4.0.6/hosts
+++ b/inventories/v4.0.6/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/playbooks/trusted_build/local_ethernet_config.yaml
+++ b/playbooks/trusted_build/local_ethernet_config.yaml
@@ -7,36 +7,42 @@
 
   tasks:
 
-    - name: Copy the local ethernet config in place
-      ansible.builtin.copy:
-        src: "files/10-ethernet.network"
-        dest: "/etc/systemd/network/10-ethernet.network"
-        owner: root
-        group: root
-        mode: 0644
+    - block:
 
-    - name: Copy the local ethernet oneshot service in place
-      ansible.builtin.copy:
-        src: "files/oneshot-local-ethernet.service"
-        dest: "/etc/systemd/system/oneshot-local-ethernet.service"
-        owner: root
-        group: root
-        mode: 0644
+      - name: Copy the local ethernet config in place
+        ansible.builtin.copy:
+          src: "files/10-ethernet.network"
+          dest: "/etc/systemd/network/10-ethernet.network"
+          owner: root
+          group: root
+          mode: 0644
 
-    # Default to off, configure during config wizard
-    - name: Configure the local ethernet oneshot service default state
-      ansible.builtin.service:
-        name: oneshot-local-ethernet
-        state: stopped
+      - name: Copy the local ethernet oneshot service in place
+        ansible.builtin.copy:
+          src: "files/oneshot-local-ethernet.service"
+          dest: "/etc/systemd/system/oneshot-local-ethernet.service"
+          owner: root
+          group: root
+          mode: 0644
+
+      # Default to off, configure during config wizard
+      - name: Configure the local ethernet oneshot service default state
+        ansible.builtin.service:
+          name: oneshot-local-ethernet
+          state: stopped
         enabled: no
 
-    # Default to off, this uses a runtime config managed by
-    # the oneshot-local-ethernet service (if enabled)
-    - name: Configure the systemd-networkd service default state
-      ansible.builtin.service:
-        name: "{{ item }}"
-        state: stopped
-        enabled: no
-      loop:
-        - systemd-networkd.socket
-        - systemd-networkd
+      # Default to off, this uses a runtime config managed by
+      # the oneshot-local-ethernet service (if enabled)
+      - name: Configure the systemd-networkd service default state
+        ansible.builtin.service:
+          name: "{{ item }}"
+          state: stopped
+          enabled: no
+        loop:
+          - systemd-networkd.socket
+          - systemd-networkd
+
+      when: enable_networking is defined and enable_networking is true
+      tags:
+        - online

--- a/playbooks/trusted_build/local_ethernet_config.yaml
+++ b/playbooks/trusted_build/local_ethernet_config.yaml
@@ -44,5 +44,3 @@
           - systemd-networkd
 
       when: enable_networking is defined and enable_networking is true
-      tags:
-        - online

--- a/playbooks/trusted_build/local_ethernet_config.yaml
+++ b/playbooks/trusted_build/local_ethernet_config.yaml
@@ -30,7 +30,7 @@
         ansible.builtin.service:
           name: oneshot-local-ethernet
           state: stopped
-        enabled: no
+          enabled: no
 
       # Default to off, this uses a runtime config managed by
       # the oneshot-local-ethernet service (if enabled)

--- a/playbooks/trusted_build/networking_packages.yaml
+++ b/playbooks/trusted_build/networking_packages.yaml
@@ -30,4 +30,3 @@
           - online
 
       when: enable_networking is defined and enable_networking is true
-

--- a/playbooks/trusted_build/networking_packages.yaml
+++ b/playbooks/trusted_build/networking_packages.yaml
@@ -1,0 +1,28 @@
+---
+
+- name: Install packages required for local networking
+  hosts: 127.0.0.1
+  connection: local
+  become: true
+
+  tasks:
+
+    - name: Clear package list
+      set_fact:
+        all_packages: []
+
+    - name: Create a list of all the networking packages we need
+      set_fact:
+        all_packages: "{{ all_packages | default([]) + [ item ] }}"
+      with_items:
+        - "{{ networking_packages | default([]) }}"
+
+    - name: De-dupe the list for efficiency
+      set_fact:
+        all_packages: "{{ all_packages | unique | select | list }}"
+
+    - name: Import the apt role which supports online and offline builds
+      ansible.builtin.import_role:
+        name: apt
+      tags:
+        - online

--- a/playbooks/trusted_build/networking_packages.yaml
+++ b/playbooks/trusted_build/networking_packages.yaml
@@ -7,22 +7,27 @@
 
   tasks:
 
-    - name: Clear package list
-      set_fact:
-        all_packages: []
+    - block:
 
-    - name: Create a list of all the networking packages we need
-      set_fact:
-        all_packages: "{{ all_packages | default([]) + [ item ] }}"
-      with_items:
-        - "{{ networking_packages | default([]) }}"
+      - name: Clear package list
+        set_fact:
+          all_packages: []
 
-    - name: De-dupe the list for efficiency
-      set_fact:
-        all_packages: "{{ all_packages | unique | select | list }}"
+      - name: Create a list of all the networking packages we need
+        set_fact:
+          all_packages: "{{ all_packages | default([]) + [ item ] }}"
+        with_items:
+          - "{{ networking_packages | default([]) }}"
 
-    - name: Import the apt role which supports online and offline builds
-      ansible.builtin.import_role:
-        name: apt
-      tags:
-        - online
+      - name: De-dupe the list for efficiency
+        set_fact:
+          all_packages: "{{ all_packages | unique | select | list }}"
+
+      - name: Import the apt role which supports online and offline builds
+        ansible.builtin.import_role:
+          name: apt
+        tags:
+          - online
+
+      when: enable_networking is defined and enable_networking is true
+

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -5,8 +5,8 @@
   become: yes
 
 - import_playbook: packages.yaml
-- import_playbook: dev_packages.yaml
 - import_playbook: networking_packages.yaml
+- import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml

--- a/playbooks/trusted_build/offline_build.yaml
+++ b/playbooks/trusted_build/offline_build.yaml
@@ -6,6 +6,7 @@
 
 - import_playbook: packages.yaml
 - import_playbook: dev_packages.yaml
+- import_playbook: networking_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml
 - import_playbook: node.yaml
 - import_playbook: rust.yaml

--- a/playbooks/trusted_build/prepare_for_build.yaml
+++ b/playbooks/trusted_build/prepare_for_build.yaml
@@ -9,6 +9,7 @@
 - import_playbook: system_links.yaml
 - import_playbook: udev-rules.yaml
 - import_playbook: packages.yaml
+- import_playbook: networking_packages.yaml
 - import_playbook: dev_packages.yaml
 - import_playbook: initialize_encrypted_volumes.yaml
 - import_playbook: node.yaml

--- a/playbooks/trusted_build/strongswan.yaml
+++ b/playbooks/trusted_build/strongswan.yaml
@@ -37,5 +37,3 @@
           enabled: yes
 
       when: enable_networking is defined and enable_networking is true
-      tags:
-        - online

--- a/playbooks/trusted_build/strongswan.yaml
+++ b/playbooks/trusted_build/strongswan.yaml
@@ -6,31 +6,36 @@
 
   tasks:
 
-    - name: Copy the strongswan config into place
-      ansible.builtin.copy:
-        src: "files/vxswan.conf"
-        dest: "/etc/swanctl/conf.d/vxswan.conf"
-        owner: root
-        group: root
-        mode: 0644
+    - block:
 
-    - name: Update the strongswan openssl config to enable fips
-      ansible.builtin.lineinfile:
-        path: /etc/strongswan.d/charon/openssl.conf
-        regexp: 'fips_mode = 0'
-        line: 'fips_mode = 1'
-        state: present
+      - name: Copy the strongswan config into place
+        ansible.builtin.copy:
+          src: "files/vxswan.conf"
+          dest: "/etc/swanctl/conf.d/vxswan.conf"
+          owner: root
+          group: root
+          mode: 0644
 
-    - name: Update the strongswan openssl config to disable legacy providers
-      ansible.builtin.lineinfile:
-        path: /etc/strongswan.d/charon/openssl.conf
-        regexp: 'load_legacy = yes'
-        line: 'load_legacy = no'
-        state: present
+      - name: Update the strongswan openssl config to enable fips
+        ansible.builtin.lineinfile:
+          path: /etc/strongswan.d/charon/openssl.conf
+          regexp: 'fips_mode = 0'
+          line: 'fips_mode = 1'
+          state: present
 
-    - name: Ensure strongswan is enabled and started on boot
-      ansible.builtin.service:
-        name: strongswan
-        state: started
-        enabled: yes
+      - name: Update the strongswan openssl config to disable legacy providers
+        ansible.builtin.lineinfile:
+          path: /etc/strongswan.d/charon/openssl.conf
+          regexp: 'load_legacy = yes'
+          line: 'load_legacy = no'
+          state: present
 
+      - name: Ensure strongswan is enabled and started on boot
+        ansible.builtin.service:
+          name: strongswan
+          state: started
+          enabled: yes
+
+      when: enable_networking is defined and enable_networking is true
+      tags:
+        - online


### PR DESCRIPTION
This PR adds the ability to enable/disable networking package installs and related configuration via an inventory config. It also breaks the networking packages into a separate list for easier management.

An initial v4.0.6 inventory has also been added and was used for testing several image builds.