### PR TITLE
add missing backslash to production preseed

### DIFF
--- a/playbooks/virtmanager/templates/production-preseed.cfg.j2
+++ b/playbooks/virtmanager/templates/production-preseed.cfg.j2
@@ -295,7 +295,7 @@ d-i partman-auto/expert_recipe string     \
     format{ }                             \
     use_filesystem{ } filesystem{ ext4 }    \
     mountpoint{ /home }                   \
-    .
+    .                                     \
     1000 300 1000 ext4                    \
     \$lvmok{ }                            \
     method{ format }                      \


### PR DESCRIPTION
This PR corrects a missing backslash that was preventing the hashes volume from being created during base image creation.