### PR TITLE
Upgrade pnpm to v9

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.4.0"
+  default = "4.5.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.4.0"
+  default = "4.5.0"
 }
 
 source "docker" "debian12" {

--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.15.5"
-    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"
+    version: "9.15.9"
+    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"

--- a/inventories/msa/group_vars/all/node.yaml
+++ b/inventories/msa/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.15.5"
-    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"
+    version: "9.15.9"
+    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.15.5"
-    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"
+    version: "9.15.9"
+    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.15.5"
-    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"
+    version: "9.15.9"
+    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"

--- a/inventories/vxpollbook-latest/group_vars/all/node.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "8.15.5"
-    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"
+    version: "9.15.9"
+    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"

--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -8,7 +8,7 @@
     node_version: "20.19.0"
     npm_packages:
       - yarn@1.22.22
-      - pnpm@8.15.5
+      - pnpm@9.15.9
 
   tasks:
 


### PR DESCRIPTION
Updates pnpm to v9.15.9 (the lastest 9.x version). See the [release notes for 9.0.0](https://github.com/pnpm/pnpm/releases/tag/v9.0.0). For vxsuite this required essentially no changes other than updating the lockfile format and the `packageManager` version strings (https://github.com/votingworks/vxsuite/pull/8519).