### PR TITLE
Add ansible plugin to `required_plugins` config

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -4,6 +4,10 @@ packer {
       version = ">= 0.0.7"
       source = "github.com/hashicorp/docker"
     }
+    ansible = {
+      version = "~> 1"
+      source = "github.com/hashicorp/ansible"
+    }
   }
 }
 

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -4,6 +4,10 @@ packer {
       version = ">= 0.0.7"
       source = "github.com/hashicorp/docker"
     }
+    ansible = {
+      version = "~> 1"
+      source = "github.com/hashicorp/ansible"
+    }
   }
 }
 


### PR DESCRIPTION
I ran into an error when setting this up on a new machine and had to install the plugin manually. I think this will tell packer to install it for you. Here's the error:

```
$ packer build docker-debian12-nodejs.pkr.hcl
Error: Unknown provisioner type "ansible-local"

  on docker-debian12-nodejs.pkr.hcl line 25:
  (source code not available)

The provisioner ansible-local is unknown by Packer, and is likely part
of a
plugin that is not installed.
You may find the needed plugin along with installation instructions
documented
on the Packer integrations page.

https://developer.hashicorp.com/packer/integrations?filter=ansible
```