### PR TITLE
Add v4.0.7 inventory (and temporarily revert new code on main since v4.0.6 for a minimal diff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ To change the name of the VM being built, use the `vm_name` variable (default is
 For example, to name your VM "MyVM":
 `packer build -var "vm_name=MyVM" parallels-debian12.pkr.hcl`
 
-## Development
-
-View our contribution guidelines [here](https://github.com/votingworks/contribution-guidelines).
-
 ## License
 
 All files are licensed under GNU GPL v3.0 only. Refer to the [license file](./LICENSE) for

--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -4,10 +4,6 @@ packer {
       version = ">= 0.0.7"
       source = "github.com/hashicorp/docker"
     }
-    ansible = {
-      version = "~> 1"
-      source = "github.com/hashicorp/ansible"
-    }
   }
 }
 

--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -13,7 +13,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.5.0"
+  default = "4.4.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -13,7 +13,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.5.0"
+  default = "4.4.0"
 }
 
 source "docker" "debian12" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -4,10 +4,6 @@ packer {
       version = ">= 0.0.7"
       source = "github.com/hashicorp/docker"
     }
-    ansible = {
-      version = "~> 1"
-      source = "github.com/hashicorp/ansible"
-    }
   }
 }
 

--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/msa/group_vars/all/node.yaml
+++ b/inventories/msa/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/v4.0.7/group_vars/all/main.yaml
+++ b/inventories/v4.0.7/group_vars/all/main.yaml
@@ -1,0 +1,15 @@
+repos:
+  vxsuite-complete-system:
+    version: v4.0.6-rc2
+virt_image_path: "/var/lib/libvirt/images"
+vm_name: "debian-v4.0.6"
+vm_disk_size_gb: 27
+iso_version: "12.2.0"
+iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"
+iso_url: "https://cdimage.debian.org/cdimage/archive/{{ iso_version }}/amd64/iso-cd"
+vm_preseed_path: "/home/{{ ansible_env.SUDO_USER }}/code/vxsuite-build-system/preseeds"
+vm_preseed_file: "production-preseed.cfg"
+secure_boot: true
+rust_version: "1.93.0"
+cloned_images:
+  - online

--- a/inventories/v4.0.7/group_vars/all/main.yaml
+++ b/inventories/v4.0.7/group_vars/all/main.yaml
@@ -1,8 +1,8 @@
 repos:
   vxsuite-complete-system:
-    version: v4.0.6-rc2
+    version: v4.0.7-rc1
 virt_image_path: "/var/lib/libvirt/images"
-vm_name: "debian-v4.0.6"
+vm_name: "debian-v4.0.7"
 vm_disk_size_gb: 27
 iso_version: "12.2.0"
 iso_name: "debian-{{ iso_version }}-amd64-netinst.iso"

--- a/inventories/v4.0.7/group_vars/all/networking.yaml
+++ b/inventories/v4.0.7/group_vars/all/networking.yaml
@@ -1,0 +1,13 @@
+---
+enable_networking: false
+
+networking_packages:
+  - avahi-daemon
+  - avahi-utils
+  - strongswan-swanctl
+  - libstrongswan-extra-plugins
+  - libstrongswan-standard-plugins
+  - charon-systemd
+  - strongswan-pki
+  - avahi-autoipd
+  - iw

--- a/inventories/v4.0.7/group_vars/all/node.yaml
+++ b/inventories/v4.0.7/group_vars/all/node.yaml
@@ -1,0 +1,8 @@
+node_version: "20.16.0"
+npm_packages:
+  yarn:
+    version: "1.22.22"
+    checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  pnpm:
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/v4.0.7/group_vars/all/packages.yaml
+++ b/inventories/v4.0.7/group_vars/all/packages.yaml
@@ -1,0 +1,126 @@
+---
+batch_package_install: true
+upgrade_kernel: true
+apt_snapshot_date: "20260519"
+release_name: "bookworm"
+
+all_packages:
+  - alsa-utils
+  - brightnessctl
+  - build-essential
+  - chromium
+  - cloud-guest-utils
+  - cryptsetup
+  - cups
+  - cups-bsd
+  - cups-client
+  - curl
+  - ddcutil
+  - default-jdk
+  - dosfstools
+  - efitools
+  - exfatprogs
+  - fdisk
+  - firewalld
+  - firmware-amd-graphics
+  - firmware-linux
+  - firmware-linux-free
+  - firmware-misc-nonfree
+  - firmware-sof-signed
+  - fonts-wqy-zenhei
+  - git
+  - gvfs
+  - gzip
+  - hplip
+  - ipp-usb
+  - iptables
+  - jq
+  - kde-cli-tools
+  - libatspi2.0-0
+  - libcairo2-dev
+  - libgif-dev
+  - libglib2.0-bin
+  - libgtk-3-0
+  - libjpeg-dev
+  - libnotify4
+  - libpango1.0-dev
+  - libpcsclite1
+  - libpcsclite-dev
+  - libpixman-1-dev
+  - libpng-dev
+  - libsane
+  - libsane1
+  - libsane-common
+  - libsane-hpaio
+  - libudev-dev
+  - libusb-1.0-0-dev
+  - libx11-dev
+  - libxss1
+  - libxtst6
+  - lm-sensors
+  - make
+  - mingetty
+  - openbox
+  - pahole
+  - parted
+  - pcscd
+  - pcsc-tools
+  - pulseaudio
+  - pulseaudio-utils
+  - rsync
+  - rsyslog
+  - ruby
+  - ruby-dev
+  - sane-airscan
+  - sane-utils
+  - sbsigntool
+  - swig
+  - systemd-boot-efi
+  - tar
+  - trash-cli
+  - unclutter
+  - unzip
+  - usbguard
+  - wget
+  - x11-common
+  - xdg-utils
+  - xinit
+  - xinput
+  - xorg
+  - xserver-xorg-core
+  - xserver-xorg-input-all
+  - xserver-xorg-input-libinput
+  - xserver-xorg-input-wacom
+  - xserver-xorg-video-all
+  - xxd
+  - zip
+
+tpm_packages:
+  - autoconf
+  - autoconf-archive
+  - automake
+  - autotools-dev
+  - libcurl4-openssl-dev
+  - libjson-c-dev
+  - libltdl-dev
+  - libqrencode4
+  - libqrencode-dev
+  - libssl-dev
+  - libtool
+  - libtss2-esys-3.0.2-0
+  - libtss2-fapi1
+  - libtss2-mu0
+  - libtss2-rc0
+  - libtss2-sys1
+  - libtss2-tcti-cmd0
+  - libtss2-tcti-device0
+  - libtss2-tctildr0
+  - libtss2-tcti-mssim0
+  - libtss2-tcti-swtpm0
+  - m4
+  - qrencode
+  - tpm2-openssl
+  - tpm2-tools
+
+dev_packages:
+  - ffmpeg

--- a/inventories/v4.0.7/group_vars/all/rubygems.yaml
+++ b/inventories/v4.0.7/group_vars/all/rubygems.yaml
@@ -1,0 +1,4 @@
+gems:
+  fpm:
+    version: "1.15.1"
+    checksum: "1ffbf342a89ca97fb5c02e66946c97e2bd5413810f7f440ddf32f00a16052dbf"

--- a/inventories/v4.0.7/group_vars/all/udev-rules.yaml
+++ b/inventories/v4.0.7/group_vars/all/udev-rules.yaml
@@ -1,0 +1,20 @@
+---
+# Note: for multi-line rules, be sure to use the pipe operator
+#       see 50-gpio for an example
+udev_rules:
+  49-sane-missing-scanner:
+    rules: ATTRS{idVendor}=="04c5", MODE="0664", GROUP="scanner", ENV{libsane_matched}="yes"
+  50-custom-scanner:
+    rules: ATTRS{idVendor}=="0dd4", MODE="0664", GROUP="scanner"
+  50-gpio:
+    rules: |
+      SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R g+rw /sys/class/gpio'"
+      SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/devices/platform/INT33FF:00/gpiochip0/gpio/* && chmod -R g+rw /sys/devices/platform/INT33FF:00/gpiochip0/gpio/*'"
+  50-pdi-scanner:
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0bd7", ATTR{idProduct}=="a002", MODE="0660", GROUP="scanner"
+  50-uinput:
+    rules: KERNEL=="uinput", MODE="0660", GROUP="uinput"
+  55-fai100:
+    rules: ATTRS{idVendor}=="28cd", ATTRS{idProduct}=="4002", MODE="0664", GROUP="fai100"
+  60-fujitsu-printer:
+    rules: SUBSYSTEM=="usb", ATTR{idVendor}=="0430", ATTR{idProduct}=="0626", MODE="0660", GROUP="plugdev"

--- a/inventories/v4.0.7/group_vars/all/users.yaml
+++ b/inventories/v4.0.7/group_vars/all/users.yaml
@@ -1,0 +1,94 @@
+---
+system_groups:
+  vx-group:
+    gid: 800
+  adm:
+  audio:
+  lpadmin:
+  scanner:
+  plugdev:
+  uinput:
+  dialout:
+  gpio:
+  fai100:
+
+system_users:
+  vx-services:
+    uid: 1750
+    homedir: /var/vx/services
+    groups: 
+      - adm
+      - audio
+      - dialout
+      - fai100
+      - gpio
+      - lpadmin
+      - plugdev
+      - scanner
+      - uinput
+      - vx-group
+    symlink: /vx/services
+  vx-ui:
+    uid: 1751
+    homedir: /var/vx/ui
+    groups: 
+      - adm
+      - audio
+      - video
+      - vx-group
+    symlink: /vx/ui
+  vx-vendor:
+    uid: 1752
+    homedir: /var/vx/vendor
+    groups:
+      - adm
+      - vx-group
+    symlink: /vx/vendor
+
+system_dirs:
+  /vx:
+    user: root
+    group: root
+  /var/vx:
+    user: root
+    group: root
+  /var/vx/config:
+    user: vx-vendor
+    group: vx-group
+  /var/vx/config/app-flags:
+    user: vx-vendor
+    group: vx-group
+  /var/vx/data:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-mark:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-mark-scan:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-scan:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/module-sems-converter:
+    user: vx-services
+    group: vx-services
+  /var/vx/data/admin-service:
+    user: vx-services
+    group: vx-services
+  /var/vx/ui:
+    user: vx-ui
+    group: vx-ui
+  /var/vx/services:
+    user: vx-services
+    group: vx-services
+  /var/vx/vendor:
+    user: vx-vendor
+    group: vx-vendor
+  /media/vx:
+    user: vx-ui
+    group: vx-group
+  /media/vx/usb-drive:
+    user: vx-ui
+    group: vx-group
+

--- a/inventories/v4.0.7/hosts
+++ b/inventories/v4.0.7/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/inventories/vxdev-stable/group_vars/all/packages.yaml
+++ b/inventories/vxdev-stable/group_vars/all/packages.yaml
@@ -57,7 +57,6 @@ all_packages:
   - libx11-dev
   - libxss1
   - libxtst6
-  - lm-sensors
   - make
   - mingetty
   - openbox

--- a/inventories/vxpollbook-latest/group_vars/all/node.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "8.15.5"
+    checksum: "a58c038faac410c947dbdb93eb30994037d0fce2"

--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -8,7 +8,7 @@
     node_version: "20.19.0"
     npm_packages:
       - yarn@1.22.22
-      - pnpm@9.15.9
+      - pnpm@8.15.5
 
   tasks:
 


### PR DESCRIPTION
Will restore the new code on main in a follow-up PR that lands right after this one. Just want a commit on main that I can tag for a v4.0.7 that's minimally different from v4.0.6 since we're so close to done with cert. I could alternatively create a release branch as I do in other repos, but I've generally avoided release branches on vxsuite-build-system since its model is to have main be a functional starting point for rebuilding any past release.

See the diff relative to v4.0.6: https://github.com/votingworks/vxsuite-build-system/compare/v4.0.6...arsalan/v4.0.7-prep - just a new inventory