### PR TITLE
Always build new machine types

### DIFF
--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -59,11 +59,7 @@ make offline-kiosk-browser
 echo "Run build.sh in complete-system. This will take several minutes."
 sleep 5
 cd $vxsuite_complete_system_dir
-if [[ "${2:-}" == "--include-new-machines" ]]; then
-  ./build.sh admin central-scan mark-scan scan mark print
-else
-  ./build.sh admin central-scan mark-scan scan
-fi
+./build.sh admin central-scan mark mark-scan print scan
 
 # Node20 upgrade has modified the permissions on some cached build dirs
 # Reset them so they can later be deleted during final image creation

--- a/scripts/tb-run-online-phase.sh
+++ b/scripts/tb-run-online-phase.sh
@@ -54,11 +54,7 @@ fi
 echo "Run prepare_build.sh in complete-system. This will take several minutes."
 sleep 5
 cd $vxsuite_complete_system_dir
-if [[ "${2:-}" == "--include-new-machines" ]]; then
-  ./prepare_build.sh admin central-scan mark-scan scan mark print
-else
-  ./prepare_build.sh admin central-scan mark-scan scan
-fi
+./prepare_build.sh admin central-scan mark mark-scan print scan
 
 echo "Download necessary tools for TPM."
 sleep 5


### PR DESCRIPTION
New machines (VxMark, VxPrint) were previously skipped during v4.0 Trusted Builds with SLI. Now that we're officially certifying these components, let's default to building them.