### PR TITLE
Address linux-base package downgrade build error

### DIFF
--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -33,9 +33,9 @@
       tags:
         - online
 
-    - name: Get the latest linux-base version available in bookworm-backports
+    - name: Get the latest linux-base version available
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-base | grep backports | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
+        cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
       register: tmp_latest_linux_base_version
       when: apt_snapshot_date is not defined
       tags:
@@ -48,7 +48,7 @@
 
     - name: Get the latest linux-base version available in VotingWorks apt repo
       ansible.builtin.shell:
-        cmd: "apt-cache madison linux-base | sort -k 3 -r | awk '{print $3}' | cut -d'|' -f1 | head -1"
+        cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
       register: tmp_latest_linux_base_version
       when: apt_snapshot_date is defined
       tags:


### PR DESCRIPTION
I hit the following error during a recent build:

> TASK [Upgrade the kernel packages and dependencies] ****************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["apt-get", "install", "-y", "--reinstall", "--install-suggests", "--no-install-recommends", "linux-base=4.12.1~bpo12+1", "linux-image-6.12.94+deb12-amd64-unsigned", "linux-headers-6.12.94+deb12-amd64"], "delta": "0:00:00.472541", "end": "2026-07-06 18:33:08.977247", "msg": "non-zero return code", "rc": 100, "start": "2026-07-06 18:33:08.504706", "stderr": "E: Packages were downgraded and -y was used without --allow-downgrades.", "stderr_lines": ["E: Packages were downgraded and -y was used without --allow-downgrades."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  debian-kernel-handbook libdw1 linux-doc-6.12\n  linux-headers-6.12.94+deb12-common linux-kbuild-6.12.94+deb12 pahole\nRecommended packages:\n  www-browser\nThe following NEW packages will be installed:\n  debian-kernel-handbook libdw1 linux-doc-6.12\n  linux-headers-6.12.94+deb12-amd64 linux-headers-6.12.94+deb12-common\n  linux-image-6.12.94+deb12-amd64-unsigned linux-kbuild-6.12.94+deb12 pahole\nThe following packages will be DOWNGRADED:\n  linux-base\n0 upgraded, 8 newly installed, 1 downgraded, 0 to remove and 0 not upgraded.", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  debian-kernel-handbook libdw1 linux-doc-6.12", "  linux-headers-6.12.94+deb12-common linux-kbuild-6.12.94+deb12 pahole", "Recommended packages:", "  www-browser", "The following NEW packages will be installed:", "  debian-kernel-handbook libdw1 linux-doc-6.12", "  linux-headers-6.12.94+deb12-amd64 linux-headers-6.12.94+deb12-common", "  linux-image-6.12.94+deb12-amd64-unsigned linux-kbuild-6.12.94+deb12 pahole", "The following packages will be DOWNGRADED:", "  linux-base", "0 upgraded, 8 newly installed, 1 downgraded, 0 to remove and 0 not upgraded."]}

We previously pulled an updated kernel from debian-backports. But it seems that debian-security now also provides the same updated kernel. The debian-security kernel version is `4.12.1~deb12u1`, and the debian-backports kernel version is `4.12.1~bpo12+1`. Current code picks the backports version `4.12.1~bpo12+1`. But Debian actually considers `4.12.1~deb12u1` more recent (I assume Debian sorts by version number and alphabetically). I've updated the code to pick out the version that'll be considered most recent by Debian later. Tested manually.