### PR TITLE
Install fonts for Arabic and Bengali

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -25,6 +25,7 @@ all_packages:
   - firmware-linux-free
   - firmware-misc-nonfree
   - firmware-sof-signed
+  - fonts-noto-core
   - fonts-wqy-zenhei
   - git
   - gvfs

--- a/inventories/v4.1.0/group_vars/all/packages.yaml
+++ b/inventories/v4.1.0/group_vars/all/packages.yaml
@@ -27,6 +27,7 @@ all_packages:
   - firmware-linux-free
   - firmware-misc-nonfree
   - firmware-sof-signed
+  - fonts-noto-core
   - fonts-wqy-zenhei
   - git
   - gvfs


### PR DESCRIPTION
While I'm not 100% sure we need these (maybe default system fonts cover Arabic and Bengali already), we ran into some issues rendering Chinese characters in production a while back and had to explicitly install a font. fonts-noto-core should give us pretty good coverage for the foreseeable future: https://packages.debian.org/bookworm/fonts-noto-core. Note that we still need to keep fonts-wqy-zenhei for Chinese as fonts-noto-core doesn't include Chinese. There's fonts-noto-cjk for that. We could switch to that but I'm leaving as is for now.