### PR TITLE
Pin Chromium to version that's compatible w current Playwright version

### DIFF
--- a/inventories/v4.1.0/group_vars/all/packages.yaml
+++ b/inventories/v4.1.0/group_vars/all/packages.yaml
@@ -8,7 +8,8 @@ all_packages:
   - alsa-utils
   - brightnessctl
   - build-essential
-  - chromium
+  - chromium=147.0.7727.137-1~deb12u1
+  - chromium-common=147.0.7727.137-1~deb12u1
   - cloud-guest-utils
   - cryptsetup
   - cups


### PR DESCRIPTION
## Overview

A bandaid patch that is fine to rely on for the duration of v4.1.0 builds because we use APT snapshots and can guarantee that the pinned version remains accessible.

Without this pin, we're pulling in Chromium 150 which appears to be incompatible with version 1.40.1 of Playwright. The vxsuite `renderToPdf` function fails with `browserType.launch: Target page, context or browser has been closed`.

Generally speaking, the preferred way to use Playwright is to let it install its own instance of Chromium that it knows to be perfectly compatible. Playwright 1.40.1 should pair with Chromium 120. But we've at least empirically found that up to Chromium 148 is fine, which is what v4.0.7 shipped with per our COTS report.

At this exact moment in time, we have these two options available to us:

```
$ apt-cache policy chromium
chromium:
  Installed: 147.0.7727.137-1~deb12u1
  Candidate: 150.0.7871.100-1~deb12u1
  Version table:
     150.0.7871.100-1~deb12u1 500
        500 http://security.debian.org/debian-security bookworm-security/main amd64 Packages
 *** 147.0.7727.137-1~deb12u1 500
        500 http://http.us.debian.org/debian bookworm/main amd64 Packages
        100 /var/lib/dpkg/status
```

Chromium 147 has been confirmed to work. Chromium 150 has been confirmed to not.

Long-term (or even medium-term i.e. by the next release), we should switch to doing the recommended thing. There's some historical context as to why we haven't, but that shouldn't be relevant anymore so long as we restrict the Chromium install to the online phase of Trusted Builds. I'll be ticketing that follow-up.

More context in https://votingworks.slack.com/archives/CJU9MSC6S/p1783472023534949