### PR TITLE
Upgrade pnpm to v10

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -13,7 +13,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.5.0"
+  default = "4.6.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -13,7 +13,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.5.0"
+  default = "4.6.0"
 }
 
 source "docker" "debian12" {

--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "10.34.5"
+    checksum: "6a91127a7f2ca72fe53bb9ff54883e0c75b22f17"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "10.34.5"
+    checksum: "6a91127a7f2ca72fe53bb9ff54883e0c75b22f17"

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "10.34.5"
+    checksum: "6a91127a7f2ca72fe53bb9ff54883e0c75b22f17"

--- a/inventories/vxpollbook-latest/group_vars/all/node.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/node.yaml
@@ -4,5 +4,5 @@ npm_packages:
     version: "1.22.22"
     checksum: "ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   pnpm:
-    version: "9.15.9"
-    checksum: "acafe6003ef0e6b24e01c24245a840f659cca155"
+    version: "10.34.5"
+    checksum: "6a91127a7f2ca72fe53bb9ff54883e0c75b22f17"

--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -8,7 +8,7 @@
     node_version: "20.19.0"
     npm_packages:
       - yarn@1.22.22
-      - pnpm@9.15.9
+      - pnpm@10.34.5
 
   tasks:
 


### PR DESCRIPTION
Follow-up to #241. See release notes: https://github.com/pnpm/pnpm/releases/tag/v10.0.0. Pairs with https://github.com/votingworks/vxsuite/pull/8898.

Updates `pnpm` to 10.34.5. The main difference in this version compared to v9 is that v10 longer runs dependency build scripts by default. Packages needing them must be listed in `pnpm.onlyBuiltDependencies` in vxsuite's `package.json`.