### PR TITLE
enable journal mode on /var partition

### DIFF
--- a/playbooks/trusted_build/files/initialize-encrypted-volumes.sh
+++ b/playbooks/trusted_build/files/initialize-encrypted-volumes.sh
@@ -50,7 +50,7 @@ mount ${decrypted_dev_path} ${partition_path}
 
 echo "Updating /etc/crypttab and /etc/fstab..."
 echo "${decrypted_map_name} ${encrypted_dev_path} ${insecure_key} try-empty-password,luks" >> /etc/crypttab
-echo "${decrypted_dev_path} ${partition_path} ext4 defaults 0 2" >> /etc/fstab 
+echo "${decrypted_dev_path} ${partition_path} ext4 defaults,data=journal 0 2" >> /etc/fstab 
 
 echo "${partition_path} encryption has been initialized."
 


### PR DESCRIPTION
This PR enables `journal` mode on the `/var` partition to address https://github.com/votingworks/vxsuite/issues/8674. The requested `fsck` functionality was already enabled.

This closes https://github.com/votingworks/vxsuite/issues/8674