### PR TITLE
Use Ansible to update the build user's home directory ownership

### DIFF
--- a/playbooks/trusted_build/post_build_config.yaml
+++ b/playbooks/trusted_build/post_build_config.yaml
@@ -5,6 +5,21 @@
   become: true
 
   tasks:
+    - import_tasks: shared_tasks/user_to_configure.yaml
+
+    - name: Override user if local_user is defined
+      set_fact:
+        user_to_configure: "{{ local_user }}"
+      when: (local_user is defined) and (local_user|length > 0)
+
+    - name: Ensure {{ user_to_configure }} directory ownership is correct
+      ansible.builtin.file:
+        path: "~{{ user_to_configure }}"
+        owner: "{{ user_to_configure }}"
+        group: "{{ user_to_configure }}"
+        recurse: yes
+        state: directory
+
     - name: Add /sbin to system default bashrc
       ansible.builtin.lineinfile:
         path: /etc/bash.bashrc

--- a/playbooks/trusted_build/post_build_config.yaml
+++ b/playbooks/trusted_build/post_build_config.yaml
@@ -14,11 +14,11 @@
 
     - name: Ensure {{ user_to_configure }} directory ownership is correct
       ansible.builtin.file:
-        path: "~{{ user_to_configure }}"
+        path: "~{{ user_to_configure }}/"
         owner: "{{ user_to_configure }}"
         group: "{{ user_to_configure }}"
         recurse: yes
-        state: directory
+        follow: no
 
     - name: Add /sbin to system default bashrc
       ansible.builtin.lineinfile:

--- a/scripts/tb-run-offline-phase.sh
+++ b/scripts/tb-run-offline-phase.sh
@@ -61,10 +61,6 @@ sleep 5
 cd $vxsuite_complete_system_dir
 ./build.sh admin central-scan mark mark-scan print scan
 
-# Node20 upgrade has modified the permissions on some cached build dirs
-# Reset them so they can later be deleted during final image creation
-sudo chown -R ${local_user}:${local_user} ${local_user_home_dir}/.*
-
 # Run shared post build config steps
 cd $vxsuite_build_system_dir
 ansible-playbook -i inventories/${ansible_inventory} playbooks/trusted_build/post_build_config.yaml


### PR DESCRIPTION
During the various Trusted Build operations, it's possible for directories/files to be created that are not owned by the build user. At the end of the build process, we delete the entire build user home directory to reclaim space and eliminate potential security vulnerabilities from an unused account. This PR uses a more efficient ansible approach to set the directory and file ownership ahead of final setup configuration. As the `complete-system` to `build-system` migration work continues, we can likely remove this step entirely.

This closes https://github.com/votingworks/vxsuite/issues/8491