### PR TITLE
Use apt preferences to manage kernel+firmware upgrades while still supporting older build versions

### DIFF
--- a/inventories/latest/group_vars/all/packages.yaml
+++ b/inventories/latest/group_vars/all/packages.yaml
@@ -2,6 +2,17 @@
 batch_package_install: true
 upgrade_kernel: true
 
+kernel_and_firmware_packages:
+  - firmware-amd-graphics
+  - firmware-linux
+  - firmware-linux-free
+  - firmware-linux-nonfree
+  - firmware-misc-nonfree
+  - firmware-sof-signed
+  - linux-base
+  - linux-image-amd64
+  - linux-headers-amd64
+
 all_packages:
   - alsa-utils
   - brightnessctl
@@ -20,11 +31,6 @@ all_packages:
   - exfatprogs
   - fdisk
   - firewalld
-  - firmware-amd-graphics
-  - firmware-linux
-  - firmware-linux-free
-  - firmware-misc-nonfree
-  - firmware-sof-signed
   - fonts-noto-core
   - fonts-wqy-zenhei
   - git

--- a/inventories/vxdev-stable/group_vars/all/packages.yaml
+++ b/inventories/vxdev-stable/group_vars/all/packages.yaml
@@ -2,6 +2,19 @@
 batch_package_install: true
 upgrade_kernel: true
 
+kernel_and_firmware_packages:
+  - firmware-amd-graphics
+  - firmware-iwlwifi
+  - firmware-linux
+  - firmware-linux-free
+  - firmware-linux-nonfree
+  - firmware-misc-nonfree
+  - firmware-realtek
+  - firmware-sof-signed
+  - linux-base
+  - linux-image-amd64
+  - linux-headers-amd64
+
 all_packages:
   - alsa-utils
   - brightnessctl
@@ -20,13 +33,6 @@ all_packages:
   - exfatprogs
   - fdisk
   - firewalld
-  - firmware-amd-graphics
-  - firmware-iwlwifi
-  - firmware-linux
-  - firmware-linux-free
-  - firmware-misc-nonfree
-  - firmware-realtek
-  - firmware-sof-signed
   - fonts-wqy-zenhei
   - git
   - gvfs

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -63,74 +63,13 @@
 
     # Old approach
     - name: Kernel upgrade
-      block:
-        - name: Get the latest linux-base version available
-          ansible.builtin.shell:
-            cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
-          register: tmp_latest_linux_base_version
-          when: apt_snapshot_date is not defined
-          tags:
-            - online
-
-        - name: Set the linux_base_version variable
-          ansible.builtin.set_fact:
-            latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
-          when: apt_snapshot_date is not defined and tmp_latest_linux_base_version is not skipped
-
-        - name: Get the latest linux-base version available in VotingWorks apt repo
-          ansible.builtin.shell:
-            cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
-          register: tmp_latest_linux_base_version
-          when: apt_snapshot_date is defined
-          tags:
-            - online
-
-        - name: Set the linux_base_version variable
-          ansible.builtin.set_fact:
-            latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
-          when: apt_snapshot_date is defined and tmp_latest_linux_base_version is not skipped
-
-        - name: Get the latest kernel image available
-          ansible.builtin.shell:
-            cmd: "apt-cache search --names-only linux-image-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
-          register: latest_kernel_image
-          tags:
-            - online
-
-        - name: Get the latest kernel headers available
-          ansible.builtin.shell:
-            cmd: "apt-cache search --names-only linux-headers-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
-          register: latest_kernel_headers
-          tags:
-            - online
-
-        - name: Upgrade the kernel packages and dependencies
-          ansible.builtin.command:
-            cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} {{ latest_kernel_image.stdout }} {{ latest_kernel_headers.stdout }}"
-          when: upgrade_kernel
-          tags:
-            - online
+      ansible.builtin.include_tasks: kernel_upgrade.yaml
       when: kernel_and_firmware_packages is not defined
     # End old approach
 
     # New approach
     - name: Kernel and firmware upgrades
-      block:
-        - name: Clear out any existing package list
-          set_fact:
-            all_packages: []
-
-        - name: Add kernel and firmware packages to be installed
-          set_fact:
-            all_packages: "{{ all_packages | default([]) + [ item ] }}"
-          with_items:
-            - "{{ kernel_and_firmware_packages | default([]) }}"
-
-        - name: Use the apt role to download or install as required
-          ansible.builtin.import_role:
-            name: apt
-          tags:
-            - online
+      ansible.builtin.include_tasks: kernel_and_firmware_upgrade.yaml
       when: kernel_and_firmware_packages is defined
     # End new approach
 

--- a/playbooks/trusted_build/kernel.yaml
+++ b/playbooks/trusted_build/kernel.yaml
@@ -1,6 +1,26 @@
 ---
 
-# TODO: install linux-kbuild based on the latest kernel installed
+# This playbook has two approaches to kernel upgrades
+# The older approach adds the bookworm-backports repo and explicitly pulls
+# the latest kernel packages and dependencies. Those would typically come
+# from the backports repo, but it is possible for some to come from the
+# security repo, so lots of extra work has gone into making that work. This
+# approach did not include firmware packages which led to increasing version
+# drift and lacked support for newer hardware models.
+#
+# The new approach adds in firmware packages. Rather than continuing to
+# manage everything manually/explicitly (which will be increasingly complex),
+# apt preferences are now used. A preference config is defined for the list
+# of kernel and firmware packages to upgrade, and the backports repo is
+# given the same weight as stable and security. Apt then makes the necessary
+# decisions to pull the latest versions and related dependencies. After the
+# upgrades are completed, backports is removed so later package installs do
+# not use that repo.
+#
+# The determining factor for which approach is used is the existence of
+# the "kernel_and_firmware_packages" list variable. If it's defined, the
+# new approach is used. If not, the old approach will be used to support
+# older builds.
 #
 - name: Install an updated kernel
   hosts: 127.0.0.1
@@ -20,8 +40,16 @@
     - name: Add bookworm-backports as an apt source
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
-        line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+        line: 'deb http://http.us.debian.org/debian bookworm-backports main non-free-firmware'
         insertbefore: "BOF"
+      when: apt_snapshot_date is not defined
+      tags:
+        - online
+
+    - name: Add bookworm-backports preference config
+      ansible.builtin.template:
+        src: "templates/bookworm-backports-kernel-pref.j2"
+        dest: "/etc/apt/preferences.d/bookworm-backports-kernel-pref"
       when: apt_snapshot_date is not defined
       tags:
         - online
@@ -33,57 +61,91 @@
       tags:
         - online
 
-    - name: Get the latest linux-base version available
-      ansible.builtin.shell:
-        cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
-      register: tmp_latest_linux_base_version
-      when: apt_snapshot_date is not defined
-      tags:
-        - online
+    # Old approach
+    - name: Kernel upgrade
+      block:
+        - name: Get the latest linux-base version available
+          ansible.builtin.shell:
+            cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
+          register: tmp_latest_linux_base_version
+          when: apt_snapshot_date is not defined
+          tags:
+            - online
 
-    - name: Set the linux_base_version variable
-      ansible.builtin.set_fact:
-        latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
-      when: apt_snapshot_date is not defined and tmp_latest_linux_base_version is not skipped
+        - name: Set the linux_base_version variable
+          ansible.builtin.set_fact:
+            latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
+          when: apt_snapshot_date is not defined and tmp_latest_linux_base_version is not skipped
 
-    - name: Get the latest linux-base version available in VotingWorks apt repo
-      ansible.builtin.shell:
-        cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
-      register: tmp_latest_linux_base_version
-      when: apt_snapshot_date is defined
-      tags:
-        - online
+        - name: Get the latest linux-base version available in VotingWorks apt repo
+          ansible.builtin.shell:
+            cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
+          register: tmp_latest_linux_base_version
+          when: apt_snapshot_date is defined
+          tags:
+            - online
 
-    - name: Set the linux_base_version variable
-      ansible.builtin.set_fact:
-        latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
-      when: apt_snapshot_date is defined and tmp_latest_linux_base_version is not skipped
+        - name: Set the linux_base_version variable
+          ansible.builtin.set_fact:
+            latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
+          when: apt_snapshot_date is defined and tmp_latest_linux_base_version is not skipped
 
-    - name: Get the latest kernel image available
-      ansible.builtin.shell:
-        cmd: "apt-cache search --names-only linux-image-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
-      register: latest_kernel_image
-      tags:
-        - online
+        - name: Get the latest kernel image available
+          ansible.builtin.shell:
+            cmd: "apt-cache search --names-only linux-image-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
+          register: latest_kernel_image
+          tags:
+            - online
 
-    - name: Get the latest kernel headers available
-      ansible.builtin.shell:
-        cmd: "apt-cache search --names-only linux-headers-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
-      register: latest_kernel_headers
-      tags:
-        - online
+        - name: Get the latest kernel headers available
+          ansible.builtin.shell:
+            cmd: "apt-cache search --names-only linux-headers-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
+          register: latest_kernel_headers
+          tags:
+            - online
 
-    - name: Upgrade the kernel packages and dependencies
-      ansible.builtin.command:
-        cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} {{ latest_kernel_image.stdout }} {{ latest_kernel_headers.stdout }}"
-      when: upgrade_kernel
-      tags:
-        - online
+        - name: Upgrade the kernel packages and dependencies
+          ansible.builtin.command:
+            cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} {{ latest_kernel_image.stdout }} {{ latest_kernel_headers.stdout }}"
+          when: upgrade_kernel
+          tags:
+            - online
+      when: kernel_and_firmware_packages is not defined
+    # End old approach
+
+    # New approach
+    - name: Kernel and firmware upgrades
+      block:
+        - name: Clear out any existing package list
+          set_fact:
+            all_packages: []
+
+        - name: Add kernel and firmware packages to be installed
+          set_fact:
+            all_packages: "{{ all_packages | default([]) + [ item ] }}"
+          with_items:
+            - "{{ kernel_and_firmware_packages | default([]) }}"
+
+        - name: Use the apt role to download or install as required
+          ansible.builtin.import_role:
+            name: apt
+          tags:
+            - online
+      when: kernel_and_firmware_packages is defined
+    # End new approach
 
     - name: Remove bookworm-backports as an apt source
       ansible.builtin.lineinfile:
         path: /etc/apt/sources.list
-        line: 'deb http://http.us.debian.org/debian bookworm-backports main'
+        line: 'deb http://http.us.debian.org/debian bookworm-backports main non-free-firmware'
+        state: absent
+      when: apt_snapshot_date is not defined
+      tags:
+        - online
+
+    - name: Remove bookworm-backports preferences config
+      ansible.builtin.file:
+        path: /etc/apt/preferences.d/bookworm-backports-kernel-pref
         state: absent
       when: apt_snapshot_date is not defined
       tags:

--- a/playbooks/trusted_build/kernel_and_firmware_upgrade.yaml
+++ b/playbooks/trusted_build/kernel_and_firmware_upgrade.yaml
@@ -1,0 +1,17 @@
+---
+
+- name: Clear out any existing package list
+  set_fact:
+    all_packages: []
+
+- name: Add kernel and firmware packages to be installed
+  set_fact:
+    all_packages: "{{ all_packages | default([]) + [ item ] }}"
+  with_items:
+    - "{{ kernel_and_firmware_packages | default([]) }}"
+
+- name: Use the apt role to download or install as required
+  ansible.builtin.import_role:
+    name: apt
+  tags:
+    - online

--- a/playbooks/trusted_build/kernel_upgrade.yaml
+++ b/playbooks/trusted_build/kernel_upgrade.yaml
@@ -1,0 +1,48 @@
+---
+
+- name: Get the latest linux-base version available
+  ansible.builtin.shell:
+    cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
+  register: tmp_latest_linux_base_version
+  when: apt_snapshot_date is not defined
+  tags:
+    - online
+
+- name: Set the linux_base_version variable
+  ansible.builtin.set_fact:
+    latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
+  when: apt_snapshot_date is not defined and tmp_latest_linux_base_version is not skipped
+
+- name: Get the latest linux-base version available in VotingWorks apt repo
+  ansible.builtin.shell:
+    cmd: "apt-cache madison linux-base | awk '{print $3}' | sort -Vr | head -1"
+  register: tmp_latest_linux_base_version
+  when: apt_snapshot_date is defined
+  tags:
+    - online
+
+- name: Set the linux_base_version variable
+  ansible.builtin.set_fact:
+    latest_linux_base_version: "{{ tmp_latest_linux_base_version.stdout }}"
+  when: apt_snapshot_date is defined and tmp_latest_linux_base_version is not skipped
+
+- name: Get the latest kernel image available
+  ansible.builtin.shell:
+    cmd: "apt-cache search --names-only linux-image-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
+  register: latest_kernel_image
+  tags:
+    - online
+
+- name: Get the latest kernel headers available
+  ansible.builtin.shell:
+    cmd: "apt-cache search --names-only linux-headers-[0-9].*deb12-amd64 | sort -V | tail -1 | awk '{print $1}'"
+  register: latest_kernel_headers
+  tags:
+    - online
+
+- name: Upgrade the kernel packages and dependencies
+  ansible.builtin.command:
+    cmd: "apt-get install -y --reinstall --install-suggests --no-install-recommends linux-base={{ latest_linux_base_version }} {{ latest_kernel_image.stdout }} {{ latest_kernel_headers.stdout }}"
+  when: upgrade_kernel
+  tags:
+    - online

--- a/playbooks/trusted_build/packages.yaml
+++ b/playbooks/trusted_build/packages.yaml
@@ -6,9 +6,14 @@
   become: true
 
   tasks:
-    - name: De-dupe the list for efficiency
+    - name: Refresh packages from the inventory
+      include_vars:
+        file: "{{ inventory_dir }}/group_vars/all/packages.yaml"
+        name: original_package_list
+
+    - name: Refresh all_packages
       set_fact:
-        all_packages: "{{ all_packages | unique | select | list }}"
+        all_packages: "{{ original_package_list.all_packages | unique | select | list }}"
 
     - name: Import the apt role which supports online and offline builds
       ansible.builtin.import_role:

--- a/playbooks/trusted_build/templates/bookworm-backports-kernel-pref.j2
+++ b/playbooks/trusted_build/templates/bookworm-backports-kernel-pref.j2
@@ -1,0 +1,3 @@
+Package: {{ kernel_and_firmware_packages | join(' ') }}
+Pin: release n=bookworm-backports
+Pin-Priority: 500


### PR DESCRIPTION
TL;DR - going forward, use apt preferences to configure the `backports` repo at the same priority as `stable` and `security` for specific kernel and firmware packages. This lets apt handle version and dependency complexity rather than having us managed increasingly complex scenarios. 

Longer version - In the past, we have manually configured our builds to use the latest kernel available in Debian's official repos, including `backports`. While that works, it's a bit fragile and has required periodic changes to handle edge cases such as dependency / version mismatches across repos. It has also meant our firmware-related packages fall further behind, which can limit our ability to use newer hardware. Rather than attempt to continue to manually handle everything involved with kernel + firmware packages, this PR uses a simpler approach via an apt preference configuration for those packages. Older build inventories are still supported. Production builds that use a specific VotingWorks apt repo are also supported.

The core change here is the use of [apt pinning via a preference file](https://wiki.debian.org/AptConfiguration#Using_pinning). Newer inventories have an additional variable (`kernel_and_firmware_packages`) defining kernel and firmware packages we want to upgrade with the `backports` repo available. Rather than manually finding the latest versions and performing all install related activities, we let the apt package manager handle it, but with the `backports` repo being granted the same priority as `stable` and `security`. Once these packages have been installed/upgraded, the `backports` repo is removed so that the remainder of our packages remain limited to the `stable` and `security` repos. 

Ansible-specific note: since we're maintaining backwards compatibility, the old and new approaches have been split into separate task files. The `kernel.yaml` playbook invokes the appropriate one based on the existence of the `kernel_and_firmware_packages` variable in a given inventory. This serves several purposes. First, it's easier to read compared to including both approaches in the main `kernel.yaml` playbook. Second, it should be easier to maintain since the old approach will remain static and doesn't need to be updated for future builds. Finally, it makes the Ansible playbook run much less noisy because irrelevant tasks do not show up as "skipped" during the run. 

