### PR TITLE
Add the ability to perform a full or shallow clone of git repos

### DIFF
--- a/inventories/vxdev-stable/group_vars/all/main.yaml
+++ b/inventories/vxdev-stable/group_vars/all/main.yaml
@@ -1,6 +1,7 @@
 repos:
   vxsuite-complete-system:
     version: main
+full_git_clone: true
 virt_image_path: "/var/lib/libvirt/images"
 vm_name: "vxdev-base"
 vm_disk_size_gb: 27

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -49,19 +49,7 @@
           mode: '0755'
         with_dict: "{{ repos }}"
     
-      #-- Note: this defaults to main AND automatically updates submodules
-      #-- You need to specify the branch/tag/commit in the repos dictionary
-      #-- if you want anything other than main
-      #- name: Clone the votingworks repos
-      #ansible.builtin.git:
-      #repo: "https://github.com/votingworks/{{ item.key }}.git"
-      #dest: "{{ download_code_directory }}/{{ item.key }}"
-      #version: "{{ item.value.version | default('main') }}"
-      #with_dict: "{{ repos }}"
-      #become: true
-      #become_user: "{{ user_to_configure }}"
-
-      - name: Shallow clone repo(s)
+      - name: Clone repos
         ansible.builtin.command: "git clone --branch {{ item.value.version | default('main') }} --depth 1 --recurse-submodules --shallow-submodules https://github.com/votingworks/{{ item.key }}.git {{ download_code_directory }}/{{ item.key }}"
         with_dict: "{{ repos }}"
         become: true

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -49,11 +49,24 @@
           mode: '0755'
         with_dict: "{{ repos }}"
     
-      - name: Clone repos
+      # Note: a shallow clone is the default unless full_git_clone is
+      # set to true in the inventory being used
+      - name: Clone repos (full)
+        ansible.builtin.git:
+          repo: "https://github.com/votingworks/{{ item.key }}.git"
+          dest: "{{ download_code_directory }}/{{ item.key }}"
+          version: "{{ item.value.version | default('main') }}"
+        with_dict: "{{ repos }}"
+        become: true
+        become_user: "{{ user_to_configure }}"
+        when: full_git_clone | default(false) | bool 
+
+      - name: Clone repos (shallow)
         ansible.builtin.command: "git clone --branch {{ item.value.version | default('main') }} --depth 1 --recurse-submodules --shallow-submodules https://github.com/votingworks/{{ item.key }}.git {{ download_code_directory }}/{{ item.key }}"
         with_dict: "{{ repos }}"
         become: true
         become_user: "{{ user_to_configure }}"
+        when: not ( full_git_clone | default(false) | bool )
 
       tags:
         - online

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -52,12 +52,17 @@
       #-- Note: this defaults to main AND automatically updates submodules
       #-- You need to specify the branch/tag/commit in the repos dictionary
       #-- if you want anything other than main
-      - name: Clone the votingworks repos
-        ansible.builtin.git:
-          repo: "https://github.com/votingworks/{{ item.key }}.git"
-          dest: "{{ download_code_directory }}/{{ item.key }}"
-          version: "{{ item.value.version | default('main') }}"
-        with_dict: "{{ repos }}"
+      #- name: Clone the votingworks repos
+      #ansible.builtin.git:
+      #repo: "https://github.com/votingworks/{{ item.key }}.git"
+      #dest: "{{ download_code_directory }}/{{ item.key }}"
+      #version: "{{ item.value.version | default('main') }}"
+      #with_dict: "{{ repos }}"
+      #become: true
+      #become_user: "{{ user_to_configure }}"
+
+      - name: Shallow clone repo(s)
+        ansible.builtin.command: "git clone --branch {{ item.value.version | default('main') }} --depth 1 --recurse-submodules --shallow-submodules https://github.com/votingworks/{{ item.key }}.git {{ download_code_directory }}/{{ item.key }}"
         become: true
         become_user: "{{ user_to_configure }}"
 

--- a/playbooks/trusted_build/repos.yaml
+++ b/playbooks/trusted_build/repos.yaml
@@ -63,6 +63,7 @@
 
       - name: Shallow clone repo(s)
         ansible.builtin.command: "git clone --branch {{ item.value.version | default('main') }} --depth 1 --recurse-submodules --shallow-submodules https://github.com/votingworks/{{ item.key }}.git {{ download_code_directory }}/{{ item.key }}"
+        with_dict: "{{ repos }}"
         become: true
         become_user: "{{ user_to_configure }}"
 


### PR DESCRIPTION
This PR makes it possible to perform a full or shallow clone based on an inventory variable. By default, a shallow clone (including shallow submodules) will be used to save disk space and speed up the clone operation. If the `full_git_clone` variable is defined as true in an inventory (see vxdev-stable for an example), a full clone (including full submodules) will be performed.

For the shallow clone, the built-in git module could not be used since it does not yet support recursive shallow clones including submodules. 