### PR TITLE
Upgrade Node to v24.19.0

### DIFF
--- a/docker-debian12-nodejs-browsers.pkr.hcl
+++ b/docker-debian12-nodejs-browsers.pkr.hcl
@@ -13,7 +13,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.6.0"
+  default = "4.7.0"
 }
 
 source "docker" "debian12-browsers" {

--- a/docker-debian12-nodejs.pkr.hcl
+++ b/docker-debian12-nodejs.pkr.hcl
@@ -13,7 +13,7 @@ packer {
 
 variable "version" {
   type = string
-  default = "4.6.0"
+  default = "4.7.0"
 }
 
 source "docker" "debian12" {

--- a/inventories/latest/group_vars/all/node.yaml
+++ b/inventories/latest/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.19.0"
+node_version: "24.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/inventories/parallels-latest/group_vars/all/node.yaml
+++ b/inventories/parallels-latest/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.19.0"
+node_version: "24.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/inventories/vxdev-stable/group_vars/all/node.yaml
+++ b/inventories/vxdev-stable/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.19.0"
+node_version: "24.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/inventories/vxpollbook-latest/group_vars/all/node.yaml
+++ b/inventories/vxpollbook-latest/group_vars/all/node.yaml
@@ -1,4 +1,4 @@
-node_version: "20.19.0"
+node_version: "24.19.0"
 npm_packages:
   yarn:
     version: "1.22.22"

--- a/playbooks/install-node.yaml
+++ b/playbooks/install-node.yaml
@@ -5,7 +5,7 @@
   become: true
 
   vars:
-    node_version: "20.19.0"
+    node_version: "24.19.0"
     npm_packages:
       - yarn@1.22.22
       - pnpm@10.34.5


### PR DESCRIPTION
## Overview

Bumps `node_version` to **24.19.0** (Krypton, active LTS through April 2028) in the rolling dev inventories (`latest`, `parallels-latest`, `vxdev-stable`, `vxpollbook-latest`) and `playbooks/install-node.yaml`, and bumps the Debian 12 CI image versions to **4.7.0**. Frozen release inventories (v4.x, cacvote) keep their pinned versions. Mirrors the structure of the pnpm v10 bump (#254).

Counterpart to votingworks/vxsuite#9112 (the monorepo Node 24 upgrade). That PR's CI fails at "Spin up environment" until `votingworks/cimg-debian12:4.7.0` (and `-browsers`) are built from this branch and pushed to Docker Hub.

## Testing Plan

- After merge (or from this branch): `packer build docker-debian12-nodejs.pkr.hcl` and `docker-debian12-nodejs-browsers.pkr.hcl`, push the 4.7.0 tags, then re-run CI on votingworks/vxsuite#9112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)