### PR TITLE
disable ipv6 any time the mesh0 interface is created

### DIFF
--- a/scripts/pollbook-files/setup_basic_mesh.sh
+++ b/scripts/pollbook-files/setup_basic_mesh.sh
@@ -35,6 +35,7 @@ fi
 echo "Bringing up the network and joining pollbook_mesh"
 sudo ip link set mesh0 up
 sudo iw dev mesh0 mesh join pollbook_mesh
+sudo sysctl -w net.ipv6.conf.mesh0.disable_ipv6=1
 
 sudo systemctl restart strongswan
 echo "Successfully joined the network."


### PR DESCRIPTION
This PR disables ipv6 support on the dynamically created `mesh0` network interface. This change would not persist across resetting the network, so it is executed every time the network is [re]created.